### PR TITLE
DoctrineProvider is renamed to MistDoctrine

### DIFF
--- a/module/Application/views/index/index.phtml
+++ b/module/Application/views/index/index.phtml
@@ -26,7 +26,7 @@
         <ul>
             <li><a href="https://github.com/zendframework/ZendSkeletonModule">ZendSkeletonModule</a> - Provides a simple starting place for developing typical MVC-oriented modules.</li>
             <li><a href="https://github.com/zendframework/ZendDeveloperTools">ZendDeveloperTools</a> - Will eventually provide a JS/CSS floating toolbar with helpful debugging tools such as profiling and debugging output.</li>
-			<li><a href="https://github.com/mstaessen/zf2-doctrine-provider">DoctrineProvider</a> - Provides a very basic Doctrine 2.x integration. By <a href="http://www.michielstaessen.be/">Michiel Staessen</a>.</li>
+            <li><a href="https://github.com/mstaessen/zf2-doctrine">MistDoctrine</a> - Provides a somewhat bare bones Doctrine 2.x integration. By <a href="http://www.michielstaessen.be/">Michiel Staessen</a>.</li>
             <li><a href="https://github.com/SpiffyJr/SpiffyDoctrine">SpiffyDoctrine</a> - Provides simple and complete integration of Doctrine 2.x for your ZF2 application. Also provides validators such as EntityExists and NoEntityExists (for use by components like Zend\Form) as well as a Zend\Authentication adapter. By <a href="http://www.spiffyjr.me/">Kyle Spraggs</a>.</li>
             <li><a href="https://github.com/Ocramius/ZfMongoDbOdm">ZfMongoDbOdm</a> - Provides a very simple integration of Doctrine MongoDB ODM 1.0.0RC1-DEV for ZF2 applications. By <a href="http://marco-pivetta.com/">Marco Pivetta</a>.</li>
             <li><a href="https://github.com/Ocramius/ZfPhpcrOdm">ZfPhpcrOdm</a> - Provides integration of Doctrine PHPCR ODM 0.9BETA for ZF2 applications both with Doctrine DBAL and Jackrabbit. By <a href="http://marco-pivetta.com/">Marco Pivetta</a>.</li>


### PR DESCRIPTION
DoctrineProvider was refactored to MistDoctrine. The Git repository location has been updated too. 
