### PR TITLE
ZfTwig module

### DIFF
--- a/module/Application/views/index/index.phtml
+++ b/module/Application/views/index/index.phtml
@@ -41,6 +41,7 @@
             <li><a href="https://github.com/DASPRiD/Bacon">Bacon</a> - Provides a unidecoder/slugifier, as well a as a PHP port of 'highlight'. By <a href="http://www.dasprids.de/">Ben Scholzen</a>.</li>
             <li><a href="https://github.com/EvanDotPro/MwopGuestbook">MwopGuestbook</a> - Provides very simple Guestbook functionality. Built as a demo for the zf-quickstart. By <a href="http://weierophinney.net/matthew/">Matthew Weier O'Phinney</a>.</li>
             <li><a href="https://github.com/silvester/ReverseUniForm">ReverseUniForm Module</a> - Implements Zend from decorators to use with Uni-Form css framework and adds some new elements. By <a href="http://maraz.org/">Silvester Maraž</a>.</li>
+            <li><a href="https://github.com/mtymek/ZfTwig">ZfTwig</a> - Provides integration of <a href="http://twig.sensiolabs.org/">Twig templating engine</a>. By <a href="https://github.com/mtymek">Mateusz Tymek</a>.</li>
         </ul>
     </div>
 </article>


### PR DESCRIPTION
This module ties ZF2 application with Twig templating engine. Please add it to modules.zendframework.com.
