### PR TITLE
Removing unmaintained module

### DIFF
--- a/module/Application/views/index/index.phtml
+++ b/module/Application/views/index/index.phtml
@@ -34,7 +34,6 @@
                     <li><a href="https://github.com/SpiffyJr/SpiffyDoctrineMongoODM">SpiffyDoctrineMongoODM</a> - MongoODM provider for SpiffyDoctrine.</li>
                 </ul>
             </li>
-            <li><a href="https://github.com/Ocramius/ZfMongoDbOdm">ZfMongoDbOdm</a> - Provides a very simple integration of Doctrine MongoDB ODM 1.0.0RC1-DEV for ZF2 applications. By <a href="http://marco-pivetta.com/">Marco Pivetta</a>.</li>
             <li><a href="https://github.com/Ocramius/ZfPhpcrOdm">ZfPhpcrOdm</a> - Provides integration of Doctrine PHPCR ODM 0.9BETA for ZF2 applications both with Doctrine DBAL and Jackrabbit. By <a href="http://marco-pivetta.com/">Marco Pivetta</a>.</li>
             <li><a href="https://github.com/EvanDotPro/EdpSuperluminal">EdpSuperluminal</a> - Caches the common Zend\* classes used by your application into a single cache file, reducing reliance on the autoloader, and greatly improving the baseline performance of ZF2. By <a href="http://blog.evan.pro/">Evan Coury</a>.</li>
             <li><a href="https://github.com/EvanDotPro/EdpUser">EdpUser</a> - Provides a very simple and customizable user authentication and registration system. The goal is to support Doctrine2.x (using SpiffyDoctrine) _AND_ Zend\Db out of the box. By <a href="http://blog.evan.pro/">Evan Coury</a>.</li>


### PR DESCRIPTION
I'm not working on the MongoDB ODM module as @SpiffyJr is currently maintaining a better solution that could eventually fit the Doctrine namespace itself. Let's just remove this to avoid confused users.
