### PR TITLE
Add several new modules

### DIFF
--- a/module/Application/views/index/index.phtml
+++ b/module/Application/views/index/index.phtml
@@ -35,6 +35,10 @@
             <li><a href="https://github.com/DASPRiD/Bacon">Bacon</a> - Provides a unidecoder/slugifier, as well a as a PHP port of 'highlight'. By <a href="http://www.dasprids.de/">Ben Scholzen</a>.</li>
             <li><a href="https://github.com/EvanDotPro/MwopGuestbook">MwopGuestbook</a> - Provides very simple Guestbook functionality. Built as a demo for the zf-quickstart. By <a href="http://weierophinney.net/matthew/">Matthew Weier O'Phinney</a>.</li>
             <li><a href="https://github.com/silvester/ReverseUniForm">ReverseUniForm Module</a> - Implements Zend from decorators to use with Uni-Form css framework and adds some new elements. By <a href="http://maraz.org/">Silvester Maraž</a>.</li>
+            <li><a href="https://github.com/juriansluiman/SlmMail">SlmMail</a> - Provides several api implementations of the largest Email Service Providers. Examples: Amazon SES, ElasticEmail, Mailchimp, Postage, Postmark, SendGrid. By <a href="http://juriansluiman.nl">Jurian Sluiman</a></li>
+            <li><a href="https://github.com/juriansluiman/SlmGoogleAnalytics">SlmGoogleAnalytics</a> - Provides integration of Google Analytics page tracking, event tracking and ecommerce tracking. By <a href="http://juriansluiman.nl">Jurian Sluiman</a></li>
+            <li><a href="https://github.com/juriansluiman/GedmoDoctrineExtensions">GedmoDoctrineExtensions</a> - Provides the Doctrine Extensions from "l3pp4rd", to be used with the DoctrineModule and DoctrineORMModule. By <a href="http://juriansluiman.nl">Jurian Sluiman</a></li>
+            <li><a href="https://github.com/juriansluiman/ChromePhpLogger">ChromePhpLogger</a> - Provides the logging utility for Chrome, able to use with Zend\Log. By <a href="http://juriansluiman.nl">Jurian Sluiman</a></li>
         </ul>
     </div>
 </article>


### PR DESCRIPTION
- SlmMail: use Zend\Mail with a variety of email service providers, like Postage, Postmark and SendGrid
- SlmGoogleAnalytics: easy Google Analytics tracking including events and ecommerce tracking
- GedmoDoctrineExtensions: simple wrapper to use the DoctrineExtensions from l3pp4rd with DoctrineModule
- ChromePhpLogger: similar to Firebug/Firephp logging, this logger provides the same features for Chrome/Chromium. Able to use with Zend\Log.
