### PR TITLE
Impleted check if module description is empty

### DIFF
--- a/module/Application/src/Application/Controller/IndexController.php
+++ b/module/Application/src/Application/Controller/IndexController.php
@@ -54,7 +54,14 @@ class IndexController extends AbstractActionController
         foreach ($repositories as $module) {
             $entry = $feed->createEntry();
             $entry->setTitle($module->getName());
-            $entry->setDescription($module->getDescription());
+
+            if($module->getDescription() == '') {
+                $moduleDescription = "No Description available";
+            } else {
+                $moduleDescription = $module->getDescription();
+            }
+
+            $entry->setDescription($moduleDescription);
             $entry->setLink($module->getUrl());
             $entry->setDateCreated(strtotime($module->getCreatedAt()));
 


### PR DESCRIPTION
Feeds are throwing an error if there is no description available for the repositories
