### PR TITLE
Fixed license formatting in module view #151

### DIFF
--- a/module/ZfModule/view/zf-module/index/view.phtml
+++ b/module/ZfModule/view/zf-module/index/view.phtml
@@ -22,7 +22,7 @@
                 ?>
             </div>
             <div class="tab-pane" id="license">
-                <pre><?php echo  $license;?></pre>
+                <pre><?php echo $license;?></pre>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Enclosed license content in `<pre></pre>` as suggested by @snapshotpl in #151.
