### PR TITLE
Enhancement: Inject mapper instead of pulling it from ServiceLocator

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -27,6 +27,9 @@ class Bootstrap
         static::$serviceManager = $serviceManager;
     }
 
+    /**
+     * @return ServiceManager
+     */
     public static function getServiceManager()
     {
         return static::$serviceManager;

--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -79,9 +79,9 @@ return array(
         ),
     ),
     'controllers' => array(
-        'invokables' => array(
-            'Application\Controller\Index' => 'Application\Controller\IndexController',
-            'Application\Controller\Search' => 'Application\Controller\SearchController',
+        'factories' => array(
+            'Application\Controller\Index' => 'Application\Controller\IndexControllerFactory',
+            'Application\Controller\Search' => 'Application\Controller\SearchControllerFactory',
         ),
     ),
     'service_manager' => array(

--- a/module/Application/src/Application/Controller/IndexController.php
+++ b/module/Application/src/Application/Controller/IndexController.php
@@ -12,10 +12,24 @@ namespace Application\Controller;
 use Zend\Mvc\Controller\AbstractActionController;
 use Zend\Feed\Writer\Feed;
 use Zend\View\Model\FeedModel;
+use ZfModule\Mapper;
 
 class IndexController extends AbstractActionController
 {
     const MODULES_PER_PAGE = 15;
+
+    /**
+     * @var Mapper\Module
+     */
+    private $moduleMapper;
+
+    /**
+     * @param Mapper\Module $moduleMapper
+     */
+    public function __construct(Mapper\Module $moduleMapper)
+    {
+        $this->moduleMapper = $moduleMapper;
+    }
 
     public function indexAction()
     {
@@ -23,9 +37,8 @@ class IndexController extends AbstractActionController
         $page = (int) $this->params('page', 1);
 
         $page = (int) $this->params()->fromRoute('page', 1);
-        $mapper = $this->getServiceLocator()->get('zfmodule_mapper_module');
 
-        $repositories = $mapper->pagination($page, self::MODULES_PER_PAGE, $query, 'created_at', 'DESC');
+        $repositories = $this->moduleMapper->pagination($page, self::MODULES_PER_PAGE, $query, 'created_at', 'DESC');
 
         return array(
             'repositories' => $repositories,
@@ -48,8 +61,8 @@ class IndexController extends AbstractActionController
 
         // Get the recent modules
         $page = 1;
-        $mapper = $this->getServiceLocator()->get('zfmodule_mapper_module');
-        $repositories = $mapper->pagination($page, self::MODULES_PER_PAGE, null, 'created_at', 'DESC');
+
+        $repositories = $this->moduleMapper->pagination($page, self::MODULES_PER_PAGE, null, 'created_at', 'DESC');
 
         // Load them into the feed
         foreach ($repositories as $module) {

--- a/module/Application/src/Application/Controller/IndexControllerFactory.php
+++ b/module/Application/src/Application/Controller/IndexControllerFactory.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/ZendSkeletonApplication for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Application\Controller;
+
+use Zend\Mvc\Controller\ControllerManager;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZfModule\Mapper;
+
+class IndexControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ServiceLocatorInterface $controllerManager
+     * @return IndexController
+     */
+    public function createService(ServiceLocatorInterface $controllerManager)
+    {
+        /* @var ControllerManager $controllerManager */
+        $serviceManager = $controllerManager->getServiceLocator();
+
+        /* @var Mapper\Module $moduleMapper */
+        $moduleMapper = $serviceManager->get('zfmodule_mapper_module');
+
+        return new IndexController($moduleMapper);
+    }
+}

--- a/module/Application/src/Application/Controller/SearchController.php
+++ b/module/Application/src/Application/Controller/SearchController.php
@@ -11,17 +11,28 @@ namespace Application\Controller;
 
 use Zend\Mvc\Controller\AbstractActionController;
 use Zend\View\Model\ViewModel;
+use ZfModule\Mapper;
 
 class SearchController extends AbstractActionController
 {
+    /**
+     * @var Mapper\Module
+     */
+    private $moduleMapper;
+
+    /**
+     * @param Mapper\Module $moduleMapper
+     */
+    public function __construct(Mapper\Module $moduleMapper)
+    {
+        $this->moduleMapper = $moduleMapper;
+    }
+
     public function indexAction()
     {
         $query =  $this->params()->fromQuery('query', null);
 
-        $sm = $this->getServiceLocator();
-        $mapper = $sm->get('zfmodule_mapper_module');
-
-        $results = $mapper->findByLike($query);
+        $results = $this->moduleMapper->findByLike($query);
 
         $viewModel = new ViewModel(array(
             'results' => $results,

--- a/module/Application/src/Application/Controller/SearchControllerFactory.php
+++ b/module/Application/src/Application/Controller/SearchControllerFactory.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/ZendSkeletonApplication for the canonical source repository
+ * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Application\Controller;
+
+use Zend\Mvc\Controller\ControllerManager;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use ZfModule\Mapper;
+
+class SearchControllerFactory implements FactoryInterface
+{
+    /**
+     * @param ServiceLocatorInterface $controllerManager
+     * @return SearchController
+     */
+    public function createService(ServiceLocatorInterface $controllerManager)
+    {
+        /* @var ControllerManager $controllerManager */
+        $serviceManager = $controllerManager->getServiceLocator();
+
+        /* @var Mapper\Module $moduleMapper */
+        $moduleMapper = $serviceManager->get('zfmodule_mapper_module');
+
+        return new SearchController($moduleMapper);
+    }
+}

--- a/module/Application/test/ApplicationTest/Controller/IndexControllerTest.php
+++ b/module/Application/test/ApplicationTest/Controller/IndexControllerTest.php
@@ -6,6 +6,7 @@ use ApplicationTest\Bootstrap;
 use Application\Controller\IndexController;
 use Zend\Http\Request;
 use Zend\Http\Response;
+use Zend\Mvc\Controller\ControllerManager;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router\RouteMatch;
 use Zend\Mvc\Router\Http\TreeRouteStack as HttpRouter;
@@ -22,7 +23,11 @@ class IndexControllerTest extends PHPUnit_Framework_TestCase
     protected function setUp()
     {
         $serviceManager = Bootstrap::getServiceManager();
-        $this->controller = new IndexController();
+
+        /* @var ControllerManager $controllerManager */
+        $controllerManager = $serviceManager->get('ControllerManager');
+        $this->controller = $controllerManager->get('Application\Controller\Index');
+
         $this->request = new Request();
         $this->routeMatch = new RouteMatch(array('controller' => 'index'));
         $this->event = new MvcEvent();


### PR DESCRIPTION
Instead of pulling dependencies in from the service locator, they should be injected by a factory.

This PR
- creates factories for `IndexController` and `SearchController` which inject the module mapper
- updates the module configuration
- updates the test setup

:bulb: Speaking of tests, the existing test doesn't assert anything, really.
