### PR TITLE
Enhancement: Use short array syntax

### DIFF
--- a/config/application.config.php
+++ b/config/application.config.php
@@ -1,8 +1,8 @@
 <?php
 ini_set('display_errors', 1);
 
-return array(
-    'modules' => array(
+return [
+    'modules' => [
         'ZF\DevelopmentMode',
         'AssetManager',
         'ZfcBase',
@@ -14,14 +14,14 @@ return array(
         'EdpModuleLayouts',
         'ZfModule',
         'EdpMarkdown',
-    ),
-    'module_listener_options' => array(
-        'config_glob_paths'    => array(
+    ],
+    'module_listener_options' => [
+        'config_glob_paths'    => [
             'config/autoload/{,*.}{global,local}.php',
-        ),
-        'module_paths' => array(
+        ],
+        'module_paths' => [
             './module',
             './vendor',
-        ),
-    ),
-);
+        ],
+    ],
+];

--- a/config/autoload/cache.local.php.dist
+++ b/config/autoload/cache.local.php.dist
@@ -1,22 +1,22 @@
 <?php
-return array(
-    'edpgithub' => array(
+return [
+    'edpgithub' => [
         /**
          * Cache configuration
          */
-        'cache' => array(
-            'adapter'   => array(
+        'cache' => [
+            'adapter'   => [
                 'name' => 'filesystem',
-                'options' => array(
+                'options' => [
                     'cache_dir' => realpath('./data/cache'),
                     'writable' => true,
-                ),
-            ),
-            'plugins' => array(
-                'exception_handler' => array('throw_exceptions' => true),
+                ],
+            ],
+            'plugins' => [
+                'exception_handler' => ['throw_exceptions' => true],
                 'serializer'
-            )
-        ),
+            ]
+        ],
         'cache_key' => 'github_api',
-    ),
-);
+    ],
+];

--- a/config/autoload/database.local.php.dist
+++ b/config/autoload/database.local.php.dist
@@ -1,14 +1,14 @@
 <?php
-return array(
-    'service_manager' => array(
-        'factories' => array(
+return [
+    'service_manager' => [
+        'factories' => [
             'Zend\Db\Adapter\Adapter' => 'Zend\Db\Adapter\AdapterServiceFactory',
-        ),
-    ),
-    'db' => array(
+        ],
+    ],
+    'db' => [
         'driver'    => 'pdo',
         'dsn'       => 'mysql:dbname=CHANGEME;host=localhost',
         'username'  => 'CHANGEME',
         'password'  => 'CHANGEME',
-    ),
-);
+    ],
+];

--- a/config/autoload/github.local.php.dist
+++ b/config/autoload/github.local.php.dist
@@ -5,7 +5,7 @@
  * If you have a ./config/autoload/ directory set up for your project, you can
  * drop this config file in it and change the values as you wish.
  */
-$settings = array(
+$settings = [
     /**
      * Github Client id
      * 
@@ -24,11 +24,11 @@ $settings = array(
      * https://github.com/settings/applications/new
      */
     'github_secret' =>'',
-);
+];
 
 /**
  * You do not need to edit below this line
  */
-return array(
+return [
     'scn-social-auth' => $settings,
-);
+];

--- a/config/autoload/global.php
+++ b/config/autoload/global.php
@@ -1,31 +1,31 @@
 <?php
-return array(
-    'module_layouts' => array(
+return [
+    'module_layouts' => [
         'ZfcUser' => 'layout/layout-small-header.phtml',
         'ZfModule' => 'layout/layout-small-header.phtml',
-    ),
-    'asset_manager' => array(
-        'caching' => array(
-            'default' => array(
+    ],
+    'asset_manager' => [
+        'caching' => [
+            'default' => [
                 'cache'     => 'FilePath',  // Apc, FilePath, FileSystem etc.
-                'options' => array(
+                'options' => [
                     'dir' => 'public',
-                ),
-            ),
-        ),
-    ),
-    'service_manager' => array(
-        'factories' => array(
+                ],
+            ],
+        ],
+    ],
+    'service_manager' => [
+        'factories' => [
             'Zend\Db\Adapter\Adapter' => 'Zend\Db\Adapter\AdapterServiceFactory',
-        ),
-        'invokables' => array(
+        ],
+        'invokables' => [
             'Zend\Session\SessionManager' => 'Zend\Session\SessionManager',
-        ),
-    ),
-    'db' => array(
+        ],
+    ],
+    'db' => [
         'driver'    => 'pdo',
         'dsn'       => 'mysql:dbname=modules;host=localhost',
         'username'  => 'modules',
         'password'  => 'modules',
-    ),
-);
+    ],
+];

--- a/config/autoload/scn-social-auth.global.php
+++ b/config/autoload/scn-social-auth.global.php
@@ -5,7 +5,7 @@
  * If you have a ./config/autoload/ directory set up for your project, you can
  * drop this config file in it and change the values as you wish.
  */
-$settings = array(
+$settings = [
     /**
      * Zend\Db\Adapter\Adapter DI Alias
      *
@@ -143,17 +143,17 @@ $settings = array(
     /**
      * End of ScnSocialAuth configuration
      */
-);
+];
 
 /**
  * You do not need to edit below this line
  */
-return array(
+return [
     'scn-social-auth' => $settings,
-    'service_manager' => array(
-        'aliases' => array(
+    'service_manager' => [
+        'aliases' => [
             'ScnSocialAuth_ZendDbAdapter' => (isset($settings['zend_db_adapter'])) ? $settings['zend_db_adapter']: 'Zend\Db\Adapter\Adapter',
             'ScnSocialAuth_ZendSessionManager' => (isset($settings['zend_session_manager'])) ? $settings['zend_session_manager']: 'Zend\Session\SessionManager',
-        ),
-    ),
-);
+        ],
+    ],
+];

--- a/config/autoload/zfcuser.global.php
+++ b/config/autoload/zfcuser.global.php
@@ -5,7 +5,7 @@
  * If you have a ./config/autoload/ directory set up for your project, you can
  * drop this config file in it and change the values as you wish.
  */
-$settings = array(
+$settings = [
     /**
      * Zend\Db\Adapter\Adapter DI Alias
      *
@@ -180,16 +180,16 @@ $settings = array(
     /**
      * End of ZfcUser configuration
      */
-);
+];
 
 /**
  * You do not need to edit below this line
  */
-return array(
+return [
     'zfcuser' => $settings,
-    'service_manager' => array(
-        'aliases' => array(
+    'service_manager' => [
+        'aliases' => [
             'zfcuser_zend_db_adapter' => (isset($settings['zend_db_adapter'])) ? $settings['zend_db_adapter']: 'Zend\Db\Adapter\Adapter',
-        ),
-    ),
-);
+        ],
+    ],
+];

--- a/config/development.config.php.dist
+++ b/config/development.config.php.dist
@@ -4,15 +4,15 @@
  * @copyright Copyright (c) 2014 Zend Technologies USA Inc. (http://www.zend.com)
  */
 
-return array(
+return [
     // Development time modules
-    'modules' => array(
+    'modules' => [
         'ZendDeveloperTools',
         'ZFTool',
         'AssetManager',
-    ),
+    ],
     // development time configuration globbing
-    'module_listener_options' => array(
-        'config_glob_paths' => array('config/autoload/{,*.}{global,local}-development.php')
-    )
-);
+    'module_listener_options' => [
+        'config_glob_paths' => ['config/autoload/{,*.}{global,local}-development.php']
+    ]
+];

--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -10,114 +10,114 @@
 use Application\Service;
 use Application\View;
 
-return array(
-    'router' => array(
-        'routes' => array(
-            'live-search' => array(
+return [
+    'router' => [
+        'routes' => [
+            'live-search' => [
                 'type'    => 'Literal',
-                'options' => array(
+                'options' => [
                     'route'    => '/live-search',
-                    'defaults' => array(
+                    'defaults' => [
                         'controller' => 'Application\Controller\Search',
                         'action'     => 'index',
-                    ),
-                ),
-            ),
-            'home' => array(
+                    ],
+                ],
+            ],
+            'home' => [
                 'type' => 'Segment',
-                'options' => array(
+                'options' => [
                     'route'    => '/[page/:page][?query=:query]',
-                    'constraints' => array(
+                    'constraints' => [
                         'page'     => '[0-9]+',
-                    ),
-                    'defaults' => array(
+                    ],
+                    'defaults' => [
                         'controller' => 'Application\Controller\Index',
                         'action'     => 'index',
-                    ),
-                ),
+                    ],
+                ],
                 'priority' => 1,
                 'may_terminate' => true,
-            ),
-            'feed' => array(
+            ],
+            'feed' => [
                 'type' => 'Literal',
-                'options' => array(
+                'options' => [
                     'route' => '/feed',
-                    'defaults' => array(
+                    'defaults' => [
                         'controller' => 'Application\Controller\Index',
                         'action' => 'feed',
-                    ),
-                ),
-            ),
+                    ],
+                ],
+            ],
 
             // The following is a route to simplify getting started creating
             // new controllers and actions without needing to create a new
             // module. Simply drop new controllers in, and you can access them
             // using the path /application/:controller/:action
-            'application' => array(
+            'application' => [
                 'type'    => 'Literal',
-                'options' => array(
+                'options' => [
                     'route'    => '/application',
-                    'defaults' => array(
+                    'defaults' => [
                         '__NAMESPACE__' => 'Application\Controller',
                         'controller'    => 'Index',
                         'action'        => 'index',
-                    ),
-                ),
+                    ],
+                ],
                 'may_terminate' => true,
-                'child_routes' => array(
-                    'default' => array(
+                'child_routes' => [
+                    'default' => [
                         'type'    => 'Segment',
-                        'options' => array(
+                        'options' => [
                             'route'    => '/[:controller[/:action]]',
-                            'constraints' => array(
+                            'constraints' => [
                                 'controller' => '[a-zA-Z][a-zA-Z0-9_-]*',
                                 'action'     => '[a-zA-Z][a-zA-Z0-9_-]*',
-                            ),
-                            'defaults' => array(
-                            ),
-                        ),
-                    ),
-                ),
-            ),
-        ),
-    ),
-    'controllers' => array(
-        'factories' => array(
+                            ],
+                            'defaults' => [
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ],
+    'controllers' => [
+        'factories' => [
             'Application\Controller\Index' => 'Application\Controller\IndexControllerFactory',
             'Application\Controller\Search' => 'Application\Controller\SearchControllerFactory',
-        ),
-    ),
-    'service_manager' => array(
-        'factories' => array(
+        ],
+    ],
+    'service_manager' => [
+        'factories' => [
             'translator' => 'Zend\I18n\Translator\TranslatorServiceFactory',
             Service\RepositoryRetriever::class => Service\RepositoryRetrieverFactory::class,
             \HTMLPurifier::class => Service\HtmlPurifierFactory::class,
-        ),
-    ),
-    'translator' => array(
+        ],
+    ],
+    'translator' => [
         'locale' => 'en_US',
-        'translation_patterns' => array(
-            array(
+        'translation_patterns' => [
+            [
                 'type'     => 'gettext',
                 'base_dir' => __DIR__ . '/../language',
                 'pattern'  => '%s.mo',
-            ),
-        ),
-    ),
-    'asset_manager' => array(
-        'resolver_configs' => array(
-            'paths' => array(
+            ],
+        ],
+    ],
+    'asset_manager' => [
+        'resolver_configs' => [
+            'paths' => [
                 __DIR__ . '/../public',
-            ),
-        ),
-    ),
-    'view_manager' => array(
+            ],
+        ],
+    ],
+    'view_manager' => [
         'display_not_found_reason' => false,
         'display_exceptions'       => false,
         'doctype'                  => 'HTML5',
         'not_found_template'       => 'error/404',
         'exception_template'       => 'error/index',
-        'template_map' => array(
+        'template_map' => [
             'layout/error'                      => __DIR__ . '/../view/layout/layout-small-header.phtml',
             'layout/layout'                     => __DIR__ . '/../view/layout/layout.phtml',
             'application/index/index'           => __DIR__ . '/../view/application/index/index.phtml',
@@ -126,16 +126,16 @@ return array(
             'error/index'                       => __DIR__ . '/../view/error/index.phtml',
             'application/helper/new-modules'    => __DIR__ . '/../view/application/helper/new-modules.phtml',
             'application/search/index'          => __DIR__ . '/../view/application/search/index.phtml',
-        ),
-        'template_path_stack' => array(
+        ],
+        'template_path_stack' => [
             __DIR__ . '/../view',
-        ),
-        'strategies' => array(
+        ],
+        'strategies' => [
             'ViewFeedStrategy',
-        ),
-    ),
-    'view_helpers' => array(
-        'factories' => array(
+        ],
+    ],
+    'view_helpers' => [
+        'factories' => [
             'sanitizeHtml' => View\Helper\SanitizeHtmlFactory::class,
             'flashMessenger' => function ($sm) {
                 $sm = $sm->getServiceLocator();
@@ -144,6 +144,6 @@ return array(
                 $helper = new View\Helper\FlashMessenger($plugin);
                 return $helper;
             }
-        )
-    ),
-);
+        ]
+    ],
+];

--- a/module/Application/src/Application/Controller/IndexController.php
+++ b/module/Application/src/Application/Controller/IndexController.php
@@ -38,10 +38,10 @@ class IndexController extends AbstractActionController
 
         $repositories = $this->moduleMapper->pagination($page, self::MODULES_PER_PAGE, $query, 'created_at', 'DESC');
 
-        return array(
+        return [
             'repositories' => $repositories,
             'query' => $query,
-        );
+        ];
     }
 
     /**

--- a/module/Application/src/Application/Controller/SearchController.php
+++ b/module/Application/src/Application/Controller/SearchController.php
@@ -34,9 +34,9 @@ class SearchController extends AbstractActionController
 
         $results = $this->moduleMapper->findByLike($query);
 
-        $viewModel = new ViewModel(array(
+        $viewModel = new ViewModel([
             'results' => $results,
-        ));
+        ]);
         $viewModel->setTerminal(true);
         return $viewModel;
     }

--- a/module/Application/src/Application/Module.php
+++ b/module/Application/src/Application/Module.php
@@ -39,8 +39,8 @@ class Module
 
     public function getServiceConfig()
     {
-        return array(
-            'factories' => array(
+        return [
+            'factories' => [
                 'ApplicationServiceErrorHandling' => function (ServiceManager $sm) {
                     $logger  = $sm->get('ZendLog');
                     $service = new ErrorHandlingService($logger);
@@ -53,8 +53,8 @@ class Module
                     $log->addWriter($writer);
                     return $log;
                 },
-            ),
-        );
+            ],
+        ];
     }
 
 

--- a/module/Application/src/Application/Service/RepositoryRetriever.php
+++ b/module/Application/src/Application/Service/RepositoryRetriever.php
@@ -47,7 +47,7 @@ class RepositoryRetriever
      *
      * @return RepositoryCollection
      */
-    public function getUserRepositories($user, $params = array())
+    public function getUserRepositories($user, $params = [])
     {
         return $this->githubClient->api('user')->repos($user, $params);
     }
@@ -100,7 +100,7 @@ class RepositoryRetriever
      *
      * @return RepositoryCollection
      */
-    public function getAuthenticatedUserRepositories($params = array())
+    public function getAuthenticatedUserRepositories($params = [])
     {
         return $this->githubClient->api('current_user')->repos($params);
     }

--- a/module/Application/test/ApplicationTest/Integration/Controller/IndexControllerTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Controller/IndexControllerTest.php
@@ -36,10 +36,10 @@ class IndexControllerTest extends PHPUnit_Framework_TestCase
         $this->controller = $controllerManager->get('Application\Controller\Index');
 
         $this->request = new Http\Request();
-        $this->routeMatch = new RouteMatch(array('controller' => 'index'));
+        $this->routeMatch = new RouteMatch(['controller' => 'index']);
         $this->event = new MvcEvent();
         $config = $serviceManager->get('Config');
-        $routerConfig = isset($config['router']) ? $config['router'] : array();
+        $routerConfig = isset($config['router']) ? $config['router'] : [];
         $router = HttpRouter::factory($routerConfig);
         $this->event->setRouter($router);
         $this->event->setRouteMatch($this->routeMatch);

--- a/module/User/config/module.config.php
+++ b/module/User/config/module.config.php
@@ -1,27 +1,27 @@
 <?php
-return array(
-    'view_manager' => array(
-        'template_map' => array(
+return [
+    'view_manager' => [
+        'template_map' => [
             'helper/module'                 =>  __DIR__ . '/../view/helper/module.phtml',
             'scn-social-auth/user/login'    =>  __DIR__ . '/../view/scn-social-auth/user/login.phtml',
             'user/helper/new-users'         =>  __DIR__ . '/../view/user/helper/new-users.phtml',
             'user/module/orgs'              =>  __DIR__ . '/../view/user/module/orgs.phtml',
             'user/module/repos'             =>  __DIR__ . '/../view/user/module/repos.phtml',
             'zfc-user/user/index'           =>  __DIR__ . '/../view/zfc-user/user/index.phtml',
-        ),
-        'template_path_stack' => array(
+        ],
+        'template_path_stack' => [
             __DIR__ . '/../view',
-        ),
-    ),
-    'controllers' => array(
-        'invokables' => array(
+        ],
+    ],
+    'controllers' => [
+        'invokables' => [
             'User\Controller\Module' => 'User\Controller\ModuleController',
-        ),
-    ),
-    'view_helpers' => array(
-        'factories' => array(
+        ],
+    ],
+    'view_helpers' => [
+        'factories' => [
             'newUsers' => 'User\View\Helper\NewUsersFactory',
             'userOrganizations' => 'User\View\Helper\UserOrganizationsFactory',
-        ),
-    ),
-);
+        ],
+    ],
+];

--- a/module/User/src/User/Mapper/User.php
+++ b/module/User/src/User/Mapper/User.php
@@ -21,7 +21,7 @@ class User extends ZfcUserMapper
         }
 
         $entity = $this->select($select);
-        $this->getEventManager()->trigger('find', $this, array('entity' => $entity));
+        $this->getEventManager()->trigger('find', $this, ['entity' => $entity]);
         return $entity;
     }
 }

--- a/module/User/src/User/Module.php
+++ b/module/User/src/User/Module.php
@@ -50,8 +50,8 @@ class Module extends AbstractModule
 
     public function getServiceConfig()
     {
-        return array(
-            'factories' => array(
+        return [
+            'factories' => [
                 'zfcuser_user_mapper' => function ($sm) {
                     $options = $sm->get('zfcuser_module_options');
                     $mapper = new Mapper\User();
@@ -61,13 +61,13 @@ class Module extends AbstractModule
                     $mapper->setHydrator(new Mapper\UserHydrator());
                     return $mapper;
                 },
-            ),
-        );
+            ],
+        ];
     }
 
     public function getAutoloaderConfig()
     {
-        return array();
+        return [];
     }
 
     public function getDir()

--- a/module/User/src/User/View/Helper/NewUsers.php
+++ b/module/User/src/User/View/Helper/NewUsers.php
@@ -36,9 +36,9 @@ class NewUsers extends AbstractHelper
     {
         $users = $this->userMapper->findAll(16, 'created_at', 'DESC');
 
-        $vm = new ViewModel(array(
+        $vm = new ViewModel([
             'users' => $users,
-        ));
+        ]);
         $vm->setTemplate('user/helper/new-users');
 
         return $this->getView()->render($vm);

--- a/module/User/src/User/View/Helper/UserOrganizations.php
+++ b/module/User/src/User/View/Helper/UserOrganizations.php
@@ -35,9 +35,9 @@ class UserOrganizations extends AbstractHelper
     public function __invoke()
     {
         $orgs = $this->githubClient->api('current_user')->orgs();
-        $vm = new ViewModel(array(
+        $vm = new ViewModel([
             'orgs' => $orgs
-        ));
+        ]);
         $vm->setTemplate('user/helper/user-organizations.phtml');
 
         return $this->getView()->render($vm);

--- a/module/ZfModule/config/module.config.php
+++ b/module/ZfModule/config/module.config.php
@@ -2,87 +2,87 @@
 use EdpGithub\Client;
 use ZfModule\Delegators\EdpGithubClientAuthenticator;
 
-return array(
-    'controllers'  => array(
-        'factories' => array(
+return [
+    'controllers'  => [
+        'factories' => [
             'ZfModule\Controller\Index' => 'ZfModule\Controller\IndexControllerFactory',
-        ),
-    ),
-    'router'       => array(
-        'routes' => array(
-            'view-module' => array(
+        ],
+    ],
+    'router'       => [
+        'routes' => [
+            'view-module' => [
                 'type'    => 'Segment',
-                'options' => array(
+                'options' => [
                     'route'    => '/:vendor/:module',
-                    'defaults' => array(
+                    'defaults' => [
                         'controller' => 'ZfModule\Controller\Index',
                         'action'     => 'view',
-                    ),
-                ),
-            ),
-            'zf-module'   => array(
+                    ],
+                ],
+            ],
+            'zf-module'   => [
                 'type'          => 'Segment',
-                'options'       => array(
+                'options'       => [
                     'route'    => '/module',
-                    'defaults' => array(
+                    'defaults' => [
                         'controller' => 'ZfModule\Controller\Index',
                         'action'     => 'index',
-                    ),
-                ),
+                    ],
+                ],
                 'may_terminate' => true,
-                'child_routes'  => array(
-                    'list'   => array(
+                'child_routes'  => [
+                    'list'   => [
                         'type'    => 'Segment',
-                        'options' => array(
+                        'options' => [
                             'route'      => '/list[/:owner]',
-                            'constrains' => array(
+                            'constrains' => [
                                 'owner' => '[a-zA-Z][a-zA-Z0-9_-]*',
-                            ),
-                            'defaults'   => array(
+                            ],
+                            'defaults'   => [
                                 'action' => 'organization',
-                            ),
-                        ),
-                    ),
-                    'add'    => array(
+                            ],
+                        ],
+                    ],
+                    'add'    => [
                         'type'    => 'Literal',
-                        'options' => array(
+                        'options' => [
                             'route'    => '/add',
-                            'defaults' => array(
+                            'defaults' => [
                                 'action' => 'add',
-                            ),
-                        ),
-                    ),
-                    'remove' => array(
+                            ],
+                        ],
+                    ],
+                    'remove' => [
                         'type'    => 'Literal',
-                        'options' => array(
+                        'options' => [
                             'route'    => '/remove',
-                            'defaults' => array(
+                            'defaults' => [
                                 'action' => 'remove',
-                            ),
-                        ),
-                    ),
-                ),
-            ),
-        ),
-    ),
-    'view_manager' => array(
-        'template_path_stack' => array(
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ],
+    'view_manager' => [
+        'template_path_stack' => [
             'zf-module' => __DIR__ . '/../view',
-        ),
-    ),
+        ],
+    ],
 
-    'view_helpers' => array(
-        'factories'  => array(
+    'view_helpers' => [
+        'factories'  => [
             'listModule'   => 'ZfModule\View\Helper\ListModuleFactory',
             'newModule'    => 'ZfModule\View\Helper\NewModuleFactory',
             'totalModules' => 'ZfModule\View\Helper\TotalModulesFactory',
-        ),
-        'invokables' => array(
+        ],
+        'invokables' => [
             'moduleView'        => 'ZfModule\View\Helper\ModuleView',
             'moduleDescription' => 'ZfModule\View\Helper\ModuleDescription',
             'composerView'      => 'ZfModule\View\Helper\ComposerView',
-        ),
-    ),
+        ],
+    ],
     'service_manager' => [
         'delegators' => [
             Client::class => [
@@ -90,4 +90,4 @@ return array(
             ],
         ],
     ],
-);
+];

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -59,14 +59,14 @@ class IndexController extends AbstractActionController
         $license = $this->repositoryRetriever->getRepositoryFileContent($vendor, $module, 'LICENSE');
         $composerConf = $this->repositoryRetriever->getRepositoryFileContent($vendor, $module, 'composer.json');
 
-        $viewModel = new ViewModel(array(
+        $viewModel = new ViewModel([
             'vendor' => $vendor,
             'module' => $module,
             'repository' => $repository,
             'readme' => $readme,
             'composerConf' => $composerConf,
             'license' => $license,
-        ));
+        ]);
 
         return $viewModel;
     }
@@ -77,17 +77,17 @@ class IndexController extends AbstractActionController
             return $this->redirect()->toRoute('zfcuser/login');
         }
 
-        $params = array(
+        $params = [
             'type'      => 'all',
             'per_page'  => 100,
             'sort'      => 'updated',
             'direction' => 'desc',
-        );
+        ];
 
         $repos = $this->repositoryRetriever->getAuthenticatedUserRepositories($params);
         $repositories = $this->fetchModules($repos);
 
-        $viewModel = new ViewModel(array('repositories' => $repositories));
+        $viewModel = new ViewModel(['repositories' => $repositories]);
         $viewModel->setTerminal(true);
         return $viewModel;
     }
@@ -99,16 +99,16 @@ class IndexController extends AbstractActionController
         }
 
         $owner = $this->params()->fromRoute('owner', null);
-        $params = array(
+        $params = [
             'per_page'  => 100,
             'sort'      => 'updated',
             'direction' => 'desc',
-        );
+        ];
 
         $repos = $this->repositoryRetriever->getUserRepositories($owner, $params);
         $repositories = $this->fetchModules($repos);
 
-        $viewModel = new ViewModel(array('repositories' => $repositories));
+        $viewModel = new ViewModel(['repositories' => $repositories]);
         $viewModel->setTerminal(true);
         $viewModel->setTemplate('zf-module/index/index.phtml');
         return $viewModel;
@@ -120,7 +120,7 @@ class IndexController extends AbstractActionController
      */
     private function fetchModules(RepositoryCollection $repos)
     {
-        $repositories = array();
+        $repositories = [];
 
         foreach ($repos as $repo) {
             $isModule = $this->moduleService->isModule($repo);

--- a/module/ZfModule/src/ZfModule/Mapper/Module.php
+++ b/module/ZfModule/src/ZfModule/Mapper/Module.php
@@ -51,7 +51,7 @@ class Module extends AbstractDbMapper implements ModuleInterface
         }
 
         $entity = $this->select($select);
-        $this->getEventManager()->trigger('find', $this, array('entity' => $entity));
+        $this->getEventManager()->trigger('find', $this, ['entity' => $entity]);
         return $entity;
     }
 
@@ -73,7 +73,7 @@ class Module extends AbstractDbMapper implements ModuleInterface
         $select->where($spec);
 
         $entity = $this->select($select);
-        $this->getEventManager()->trigger('find', $this, array('entity' => $entity));
+        $this->getEventManager()->trigger('find', $this, ['entity' => $entity]);
         return $entity;
     }
 
@@ -93,37 +93,37 @@ class Module extends AbstractDbMapper implements ModuleInterface
         }
 
         $entity = $this->select($select);
-        $this->getEventManager()->trigger('find', $this, array('entity' => $entity));
+        $this->getEventManager()->trigger('find', $this, ['entity' => $entity]);
         return $entity;
     }
 
     public function findByName($name)
     {
         $select = $this->getSelect()
-                       ->where(array('name' => $name));
+                       ->where(['name' => $name]);
 
         $entity = $this->select($select)->current();
-        $this->getEventManager()->trigger('find', $this, array('entity' => $entity));
+        $this->getEventManager()->trigger('find', $this, ['entity' => $entity]);
         return $entity;
     }
 
     public function findByUrl($url)
     {
         $select = $this->getSelect()
-                       ->where(array('url' => $url));
+                       ->where(['url' => $url]);
 
         $entity = $this->select($select)->current();
-        $this->getEventManager()->trigger('find', $this, array('entity' => $entity));
+        $this->getEventManager()->trigger('find', $this, ['entity' => $entity]);
         return $entity;
     }
 
     public function findById($id)
     {
         $select = $this->getSelect()
-                       ->where(array('module_id' => $id));
+                       ->where(['module_id' => $id]);
 
         $entity = $this->select($select)->current();
-        $this->getEventManager()->trigger('find', $this, array('entity' => $entity));
+        $this->getEventManager()->trigger('find', $this, ['entity' => $entity]);
         return $entity;
     }
 
@@ -154,7 +154,7 @@ class Module extends AbstractDbMapper implements ModuleInterface
     public function getTotal()
     {
         $select = $this->getSelect();
-        $select->columns(array('num' => new Expression('COUNT(*)')));
+        $select->columns(['num' => new Expression('COUNT(*)')]);
 
         $stmt = $this->getSlaveSql()->prepareStatementForSqlObject($select);
 

--- a/module/ZfModule/src/ZfModule/Module.php
+++ b/module/ZfModule/src/ZfModule/Module.php
@@ -30,8 +30,8 @@ class Module
 
     public function getServiceConfig()
     {
-        return array(
-            'factories' => array(
+        return [
+            'factories' => [
                 'zfmodule_mapper_module' => function ($sm) {
                     $mapper = new Mapper\Module();
                     $mapper->setDbAdapter($sm->get('zfcuser_zend_db_adapter'));
@@ -40,7 +40,7 @@ class Module
                     return $mapper;
                 },
                 'zfmodule_service_module' => 'ZfModule\Service\ModuleFactory',
-            )
-        );
+            ]
+        ];
     }
 }

--- a/module/ZfModule/src/ZfModule/View/Helper/ComposerView.php
+++ b/module/ZfModule/src/ZfModule/View/Helper/ComposerView.php
@@ -20,9 +20,9 @@ class ComposerView extends AbstractHelper
      */
     public function __invoke($composerConf)
     {
-        $vm = new ViewModel(array(
+        $vm = new ViewModel([
             'composerConf' => $composerConf,
-        ));
+        ]);
         $vm->setTemplate('zf-module/helper/composer-view.phtml');
 
 

--- a/module/ZfModule/src/ZfModule/View/Helper/ListModule.php
+++ b/module/ZfModule/src/ZfModule/View/Helper/ListModule.php
@@ -47,7 +47,7 @@ class ListModule extends AbstractHelper
                 'per_page' => 100
             ]);
 
-            $modules = array();
+            $modules = [];
             foreach ($repositories as $repository) {
                 if (!$repository->fork && $repository->permissions->push) {
                     $module = $this->moduleMapper->findByName($repository->name);

--- a/module/ZfModule/src/ZfModule/View/Helper/ModuleDescription.php
+++ b/module/ZfModule/src/ZfModule/View/Helper/ModuleDescription.php
@@ -20,9 +20,9 @@ class ModuleDescription extends AbstractHelper
      */
     public function __invoke($module)
     {
-        $vm = new ViewModel(array(
+        $vm = new ViewModel([
             'module' => $module,
-        ));
+        ]);
         $vm->setTemplate('zf-module/helper/module-description.phtml');
 
 

--- a/module/ZfModule/src/ZfModule/View/Helper/ModuleView.php
+++ b/module/ZfModule/src/ZfModule/View/Helper/ModuleView.php
@@ -20,10 +20,10 @@ class ModuleView extends AbstractHelper
      */
     public function __invoke($module, $button = 'submit')
     {
-        $vm = new ViewModel(array(
+        $vm = new ViewModel([
             'module' => $module,
             'button' => $button,
-        ));
+        ]);
         $vm->setTemplate('zf-module/helper/module-view.phtml');
 
 

--- a/module/ZfModule/src/ZfModule/View/Helper/NewModule.php
+++ b/module/ZfModule/src/ZfModule/View/Helper/NewModule.php
@@ -29,9 +29,9 @@ class NewModule extends AbstractHelper
         $modules = $this->moduleMapper->findAll(10, 'created_at', 'DESC');
 
         //return $modules;
-        $vm = new ViewModel(array(
+        $vm = new ViewModel([
             'modules' => $modules,
-        ));
+        ]);
         $vm->setTemplate('zf-module/helper/new-module');
 
         return $this->getView()->render($vm);

--- a/module/ZfModule/src/ZfModule/View/Helper/OwnerModuleList.php
+++ b/module/ZfModule/src/ZfModule/View/Helper/OwnerModuleList.php
@@ -37,9 +37,9 @@ class OwnerModuleList extends AbstractHelper implements ServiceLocatorAwareInter
         $modules = $mapper->findByOwner($options["owner"], 10, 'created_at', 'DESC');
 
         //return $modules;
-        $vm = new ViewModel(array(
+        $vm = new ViewModel([
             'modules' => $modules,
-        ));
+        ]);
         $vm->setTemplate('zf-module/helper/new-module.phtml');
 
         return $this->getView()->render($vm);


### PR DESCRIPTION
Since this is what `composer.json` says

```json
{
    "require": {
        "php": ">=5.5.0"
    }
}
```

I guess it makes a lot of sense to use short array syntax.

Used https://github.com/thomasbachem/php-short-array-syntax-converter for this.