### PR TITLE
Fix: Remove unused service factory

### DIFF
--- a/module/ZfModule/src/ZfModule/Module.php
+++ b/module/ZfModule/src/ZfModule/Module.php
@@ -45,20 +45,6 @@ class Module
                     $mapper->setHydrator(new Mapper\ModuleHydrator());
                     return $mapper;
                 },
-                'zfmodule_service_repository' => function ($sm) {
-                    $service = new Service\Repository;
-                    $service->setApi($sm->get('EdpGithub\Client'));
-                    return $service;
-                },
-                /*'github_client' => function ($sm) {
-                    $hybridAuth = $sm->get('HybridAuth');
-                    $adapter = $hybridAuth->getAdapter('github');
-                    $token = $adapter->getAccessToken();
-
-                    $client = $sm->get('EdpGithubClient');
-                    $client->authenticate('url_token',$token['access_token'], null);
-                    return $client;
-                }*/
             ),
             'invokables' => array(
                 'zfmodule_service_module' => 'ZfModule\Service\Module',


### PR DESCRIPTION
This PR 
- [x] removes the service with the identifier `zfmodule_service_repository` which is not just never used, but would also attempt to create an instance of a class which does not exist
- [x] removes some dead code
