### PR TITLE
Fix: Maintain sensible order of PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 php:
-  - 5.5
   - 5.4
-  - hhvm 
+  - 5.5
+  - hhvm
 
 before_script:
   - composer update --prefer-source


### PR DESCRIPTION
I think it's a good idea to run against different versions in a sensible order, probably should have pointed that out in #244.
