### PR TITLE
Fix: Install dependencies within install section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ php:
   - hhvm 
 
 install:
-  - composer update --prefer-source
+  - composer install --prefer-source
 
 script:
   - ./vendor/bin/phpcs --standard=./phpcs.xml -np --report=summary .


### PR DESCRIPTION
Because that's what the `install` section of `.travis.yml` is for. Also, actually install dependencies, don't update them.
