### PR TITLE
Fix: Unknown service

### DIFF
--- a/module/User/src/User/View/Helper/UserRepositories.php
+++ b/module/User/src/User/View/Helper/UserRepositories.php
@@ -57,7 +57,7 @@ class UserRepositories extends AbstractHelper implements ServiceLocatorAwareInte
             $repositories[] = $repo;
         }
 
-        $mapper = $sl->get('application_module_mapper');
+        $mapper = $sl->get('zfmodule_mapper_module');
         foreach ($repositories as $key => $repo) {
             if ($repo->fork) {
                 unset($repositories[$key]);


### PR DESCRIPTION
A service with the identifier `application_module_mapper` is not registered. The required service should probably be `zfmodule_mapper_module`.

There is only one class in the entire project that implements a method `findByName()`, and that is `ZfModule\Mapper\Module`, of which an instance is returned when attempting to retrieve a service with the identifier `zfmodule_mapper_module`.

Came across this when working on injecting dependencies into the view helpers in the `User` module and my tests failed.
