### PR TITLE
Fix: Avoid magic string literals

### DIFF
--- a/module/Application/test/ApplicationTest/Integration/Controller/IndexControllerTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Controller/IndexControllerTest.php
@@ -3,9 +3,7 @@
 namespace ApplicationTest\Integration\Controller;
 
 use ApplicationTest\Integration\Util\Bootstrap;
-use Application\Controller\IndexController;
-use Zend\Http\Request;
-use Zend\Http\Response;
+use Zend\Http;
 use Zend\Mvc\Controller\ControllerManager;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\Router\RouteMatch;
@@ -28,7 +26,7 @@ class IndexControllerTest extends PHPUnit_Framework_TestCase
         $controllerManager = $serviceManager->get('ControllerManager');
         $this->controller = $controllerManager->get('Application\Controller\Index');
 
-        $this->request = new Request();
+        $this->request = new Http\Request();
         $this->routeMatch = new RouteMatch(array('controller' => 'index'));
         $this->event = new MvcEvent();
         $config = $serviceManager->get('Config');
@@ -47,6 +45,6 @@ class IndexControllerTest extends PHPUnit_Framework_TestCase
         //$result = $this->controller->dispatch($this->request);
         //$response = $this->controller->getResponse();
 
-        //$this->assertEquals(200, $response->getStatusCode());
+        //$this->assertEquals(Http\Response::STATUS_CODE_200, $response->getStatusCode());
     }
 }

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -5,6 +5,7 @@ namespace ZfModule\Controller;
 use EdpGithub\Client;
 use EdpGithub\Collection\RepositoryCollection;
 use Zend\Cache;
+use Zend\Http;
 use Zend\Mvc\Controller\AbstractActionController;
 use Zend\View\Model\ViewModel;
 use ZfModule\Mapper;
@@ -57,7 +58,7 @@ class IndexController extends AbstractActionController
 
         $result = $this->moduleMapper->findByName($module);
         if (!$result) {
-            $this->getResponse()->setStatusCode(404);
+            $this->getResponse()->setStatusCode(Http\Response::STATUS_CODE_404);
             return;
         }
 
@@ -66,7 +67,7 @@ class IndexController extends AbstractActionController
         $repository = json_decode($this->githubClient->api('repos')->show($vendor, $module));
         $httpClient = $this->githubClient->getHttpClient();
         $response= $httpClient->getResponse();
-        if ($response->getStatusCode() == 304 && $this->moduleCache->hasItem($cacheKey)) {
+        if ($response->getStatusCode() == Http\Response::STATUS_CODE_304 && $this->moduleCache->hasItem($cacheKey)) {
             return $this->moduleCache->getItem($cacheKey);
         }
 
@@ -177,7 +178,7 @@ class IndexController extends AbstractActionController
 
             $hasCache = $this->moduleCache->hasItem($cacheKey);
 
-            if ($response->getStatusCode() == 304 && $hasCache) {
+            if ($response->getStatusCode() == Http\Response::STATUS_CODE_304 && $hasCache) {
                 $repositories = $this->moduleCache->getItem($cacheKey);
                 break;
             }
@@ -216,7 +217,7 @@ class IndexController extends AbstractActionController
             if (!($repository instanceof \stdClass)) {
                 throw new Exception\RuntimeException(
                     'Not able to fetch the repository from github due to an unknown error.',
-                    500
+                    Http\Response::STATUS_CODE_500
                 );
             }
 
@@ -227,14 +228,14 @@ class IndexController extends AbstractActionController
                 } else {
                     throw new Exception\UnexpectedValueException(
                         $repository->name . ' is not a Zend Framework Module',
-                        403
+                        Http\Response::STATUS_CODE_403
                     );
                 }
             } else {
                 throw new Exception\UnexpectedValueException(
                     'You have no permission to add this module. The reason might be that you are' .
                     'neither the owner nor a collaborator of this repository.',
-                    403
+                    Http\Response::STATUS_CODE_403
                 );
             }
         } else {
@@ -278,7 +279,7 @@ class IndexController extends AbstractActionController
             if (!$repository instanceof \stdClass) {
                 throw new Exception\RuntimeException(
                     'Not able to fetch the repository from github due to an unknown error.',
-                    500
+                    Http\Response::STATUS_CODE_500
                 );
             }
 
@@ -290,14 +291,14 @@ class IndexController extends AbstractActionController
                 } else {
                     throw new Exception\UnexpectedValueException(
                         $repository->name . ' was not found',
-                        403
+                        Http\Response::STATUS_CODE_403
                     );
                 }
             } else {
                 throw new Exception\UnexpectedValueException(
                     'You have no permission to add this module. The reason might be that you are' .
                     'neither the owner nor a collaborator of this repository.',
-                    403
+                    Http\Response::STATUS_CODE_403
                 );
             }
         } else {


### PR DESCRIPTION
Why would you use string literals when there are constants you could refer to?
