### PR TITLE
Fix: Add missing comma in array initialization

### DIFF
--- a/config/autoload/development.local.php.dist
+++ b/config/autoload/development.local.php.dist
@@ -3,7 +3,7 @@
 return [
     'view_manager' => [
         'display_exceptions' => true,
-    ]
+    ],
     'service_manager' => [
         'factories' => [
             'Zend\Db\Adapter\Adapter' => 'BjyProfiler\Db\Adapter\ProfilingAdapterFactory',


### PR DESCRIPTION
A missing `,` in `config/autoload/development.local.php.dist` results in the following error

```
Parse error: syntax error, unexpected ''service_manager'' (T_CONSTANT_ENCAPSED_STRING), expecting ']' in /Users/am/Sites/zendframework/modules.zendframework.com/config/autoload/development.local.php on line 7
```

when switching the application into development mode via

```
$ php public/index.php development enable
```

and then navigating to, let's say, http://modules.zendframework.dev.
