### PR TITLE
gitHubToLocalUser event no longer exists in ScnSocialAuth module

### DIFF
--- a/module/User/src/User/Module.php
+++ b/module/User/src/User/Module.php
@@ -19,8 +19,14 @@ class Module extends AbstractModule
         $em = $app->getEventManager()->getSharedManager();
         $sm = $app->getServiceManager();
 
-        $em->attach('ScnSocialAuth\Authentication\Adapter\HybridAuth', 'githubToLocalUser', function ($e) {
-            $localUser = $e->getTarget();
+        $em->attach('ScnSocialAuth\Authentication\Adapter\HybridAuth', 'registerViaProvider', function ($e) {
+            $provider = $e->getParam('provider');
+
+            if ('github' !== $provider) {
+                return;
+            }
+
+            $localUser = $e->getParam('user');
             $userProfile = $e->getParam('userProfile');
             $nickname = substr(
                 $userProfile->profileURL,


### PR DESCRIPTION
`gitHubToLocalUser` event has been deprecated and removed from `socalnick/scn-social-auth` module in https://github.com/SocalNick/ScnSocialAuth/pull/130. We need to use general `registerViaProvider` event and check for specific `github` provider.
