### PR TITLE
github registration listener refactoring + tests

### DIFF
--- a/module/User/config/module.config.php
+++ b/module/User/config/module.config.php
@@ -24,4 +24,9 @@ return [
             'userOrganizations' => 'User\View\Helper\UserOrganizationsFactory',
         ],
     ],
+    'service_manager' => [
+        'invokables' => [
+            'User\GitHub\LoginListener' => 'User\GitHub\LoginListener',
+        ],
+    ],
 ];

--- a/module/User/src/User/GitHub/LoginListener.php
+++ b/module/User/src/User/GitHub/LoginListener.php
@@ -45,7 +45,7 @@ final class LoginListener implements ListenerAggregateInterface
      * @param EventInterface $event
      * @return bool
      */
-    protected function isEventValid(EventInterface $event)
+    private function isEventValid(EventInterface $event)
     {
         if (!$event->getParam('provider')) {
             return false;
@@ -74,7 +74,7 @@ final class LoginListener implements ListenerAggregateInterface
      * @param Hybrid_User_Profile $profile
      * @return User
      */
-    protected function updateLocalUser(User $user, Hybrid_User_Profile $profile)
+    private function updateLocalUser(User $user, Hybrid_User_Profile $profile)
     {
         $user->setUsername($this->getUsernameFromProfileUrl($profile->profileURL));
         $user->setPhotoUrl($profile->photoURL);
@@ -86,7 +86,7 @@ final class LoginListener implements ListenerAggregateInterface
      * @param string $url GitHub profile URL
      * @return string
      */
-    protected function getUsernameFromProfileUrl($url)
+    private function getUsernameFromProfileUrl($url)
     {
         return substr($url, (strrpos($url, '/') + 1));
     }

--- a/module/User/src/User/GitHub/LoginListener.php
+++ b/module/User/src/User/GitHub/LoginListener.php
@@ -57,12 +57,12 @@ final class LoginListener implements ListenerAggregateInterface
         }
 
         // check if there is an User entity
-        if (!$event->getParam('user') || !($event->getParam('user') instanceof User)) {
+        if (!$event->getParam('user') instanceof User) {
             return false;
         }
 
         // check if there is a Hybrid_User_Profile entity
-        if (!$event->getParam('userProfile') || !($event->getParam('userProfile') instanceof Hybrid_User_Profile)) {
+        if (!$event->getParam('userProfile') instanceof Hybrid_User_Profile) {
             return false;
         }
 

--- a/module/User/src/User/GitHub/LoginListener.php
+++ b/module/User/src/User/GitHub/LoginListener.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace User\GitHub;
+
+use Hybrid_User_Profile;
+use User\Entity\User;
+use Zend\EventManager\EventInterface;
+use Zend\EventManager\EventManagerInterface;
+use Zend\EventManager\ListenerAggregateInterface;
+use Zend\EventManager\ListenerAggregateTrait;
+
+final class LoginListener implements ListenerAggregateInterface
+{
+    use ListenerAggregateTrait;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function attach(EventManagerInterface $events)
+    {
+        $sharedEvents      = $events->getSharedManager();
+        $this->listeners[] = $sharedEvents->attach(
+            'ScnSocialAuth\Authentication\Adapter\HybridAuth',
+            'registerViaProvider',
+            [$this, 'onRegister']
+        );
+    }
+
+    /**
+     * @param EventInterface $event
+     */
+    public function onRegister(EventInterface $event)
+    {
+        if (!$this->isEventValid($event)) {
+            return;
+        }
+
+        $localUser = $event->getParam('user');
+        $userProfile = $event->getParam('userProfile');
+
+        $this->updateLocalUser($localUser, $userProfile);
+    }
+
+    /**
+     * @param EventInterface $event
+     * @return bool
+     */
+    protected function isEventValid(EventInterface $event)
+    {
+        if (!$event->getParam('provider')) {
+            return false;
+        }
+
+        // apply only on GitHub login
+        if ('github' !== $event->getParam('provider')) {
+            return false;
+        }
+
+        // check if there is an User entity
+        if (!$event->getParam('user') || !($event->getParam('user') instanceof User)) {
+            return false;
+        }
+
+        // check if there is a Hybrid_User_Profile entity
+        if (!$event->getParam('userProfile') || !($event->getParam('userProfile') instanceof Hybrid_User_Profile)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param User $user
+     * @param Hybrid_User_Profile $profile
+     * @return User
+     */
+    protected function updateLocalUser(User $user, Hybrid_User_Profile $profile)
+    {
+        $user->setUsername($this->getUsernameFromProfileUrl($profile->profileURL));
+        $user->setPhotoUrl($profile->photoURL);
+
+        return $user;
+    }
+
+    /**
+     * @param string $url GitHub profile URL
+     * @return string
+     */
+    protected function getUsernameFromProfileUrl($url)
+    {
+        return substr($url, (strrpos($url, '/') + 1));
+    }
+}

--- a/module/User/src/User/Module.php
+++ b/module/User/src/User/Module.php
@@ -19,22 +19,7 @@ class Module extends AbstractModule
         $em = $app->getEventManager()->getSharedManager();
         $sm = $app->getServiceManager();
 
-        $em->attach('ScnSocialAuth\Authentication\Adapter\HybridAuth', 'registerViaProvider', function ($e) {
-            $provider = $e->getParam('provider');
-
-            if ('github' !== $provider) {
-                return;
-            }
-
-            $localUser = $e->getParam('user');
-            $userProfile = $e->getParam('userProfile');
-            $nickname = substr(
-                $userProfile->profileURL,
-                (strrpos($userProfile->profileURL, "/") + 1)
-            );
-            $localUser->setUsername($nickname);
-            $localUser->setPhotoUrl($userProfile->photoURL);
-        });
+        $app->getEventManager()->attach($sm->get('User\GitHub\LoginListener'));
 
         $em->attach('EdpGithub\Client', 'api', function ($e) use ($sm) {
             $hybridAuth = $sm->get('HybridAuth');

--- a/module/User/src/User/Module.php
+++ b/module/User/src/User/Module.php
@@ -19,8 +19,7 @@ class Module extends AbstractModule
         $em = $app->getEventManager()->getSharedManager();
         $sm = $app->getServiceManager();
 
-        $app->getEventManager()->attach($sm->get('User\GitHub\LoginListener'));
-
+        $em->attachAggregate($sm->get('User\GitHub\LoginListener'));
         $em->attach('EdpGithub\Client', 'api', function ($e) use ($sm) {
             $hybridAuth = $sm->get('HybridAuth');
             $adapter = $hybridAuth->getAdapter('github');

--- a/module/User/test/UserTest/GitHub/LoginListenerTest.php
+++ b/module/User/test/UserTest/GitHub/LoginListenerTest.php
@@ -24,12 +24,12 @@ class LoginListenerTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers \User\GitHub\LoginListener::attach
+     * @covers \User\GitHub\LoginListener::attachShared
      */
     public function testAttach()
     {
         $eventManager = new EventManager();
-        $this->listener->attach($eventManager);
+        $this->listener->attachShared($eventManager->getSharedManager());
 
         $listeners = $eventManager->getSharedManager()
             ->getListeners('ScnSocialAuth\Authentication\Adapter\HybridAuth', 'registerViaProvider');

--- a/module/User/test/UserTest/GitHub/LoginListenerTest.php
+++ b/module/User/test/UserTest/GitHub/LoginListenerTest.php
@@ -1,0 +1,180 @@
+<?php
+
+namespace UserTest\GitHub;
+
+use Hybrid_User_Profile;
+use PHPUnit_Framework_TestCase;
+use ReflectionClass;
+use User\Entity\User;
+use User\GitHub\LoginListener;
+use Zend\EventManager\Event;
+use Zend\EventManager\EventManager;
+
+/**
+ * Test case for {@see \User\GitHub\LoginListener}
+ */
+class LoginListenerTest extends PHPUnit_Framework_TestCase
+{
+    /** @var LoginListener */
+    protected $listener;
+
+    protected function setUp()
+    {
+        $this->listener = new LoginListener();
+    }
+
+    /**
+     * @covers \User\GitHub\LoginListener::attach
+     */
+    public function testAttach()
+    {
+        $eventManager = new EventManager();
+        $this->listener->attach($eventManager);
+
+        $listeners = $eventManager->getSharedManager()
+            ->getListeners('ScnSocialAuth\Authentication\Adapter\HybridAuth', 'registerViaProvider');
+
+        $this->assertFalse($listeners->isEmpty());
+    }
+
+    /**
+     * @covers \User\GitHub\LoginListener::onRegister
+     */
+    public function testOnRegisterWithValidEvent()
+    {
+        $user = new User();
+        $profile = new Hybrid_User_Profile();
+        $photoUrl = 'http://placehold.it/50x50';
+        $profile->photoURL = $photoUrl;
+        $profile->profileURL = 'https://github.com/username';
+
+        $event = new Event(null, null, [
+            'user'        => $user,
+            'userProfile' => $profile,
+            'provider'    => 'github',
+        ]);
+
+        $this->listener->onRegister($event);
+
+        $this->assertSame('username', $user->getUsername());
+        $this->assertSame($photoUrl, $user->getPhotoUrl());
+    }
+
+    /**
+     * @covers \User\GitHub\LoginListener::onRegister
+     */
+    public function testOnRegisterWithInvalidEvent()
+    {
+        $user = new User();
+        $profile = new Hybrid_User_Profile();
+        $event = new Event(null, null, [
+            'user'        => $user,
+            'userProfile' => $profile,
+        ]);
+
+        $this->listener->onRegister($event);
+
+        $this->assertEquals($user, $user);
+    }
+
+    /**
+     * @dataProvider getEvents
+     * @covers \User\GitHub\LoginListener::isEventValid
+     */
+    public function testIsEventValid($event, $expectedValidity)
+    {
+        $class = new ReflectionClass($this->listener);
+        $method = $class->getMethod('isEventValid');
+        $method->setAccessible(true);
+
+        $result = $method->invokeArgs($this->listener, [$event]);
+        $this->assertEquals($expectedValidity, $result);
+    }
+
+    /**
+     * @covers \User\GitHub\LoginListener::updateLocalUser
+     */
+    public function testUpdateLocalUser()
+    {
+        $user = new User();
+        $profile = new Hybrid_User_Profile();
+        $photoUrl = 'http://placehold.it/50x50';
+        $profile->photoURL = $photoUrl;
+        $profile->profileURL = 'https://github.com/username';
+
+        $class = new ReflectionClass($this->listener);
+        $method = $class->getMethod('updateLocalUser');
+        $method->setAccessible(true);
+        $result =  $method->invokeArgs($this->listener, [$user, $profile]);
+
+        $this->assertSame('username', $result->getUsername());
+        $this->assertSame($photoUrl, $result->getPhotoUrl());
+    }
+
+    /**
+     * @covers \User\GitHub\LoginListener::getUsernameFromProfileUrl
+     */
+    public function testGetUsernameFromProfileUrl()
+    {
+        $class = new ReflectionClass($this->listener);
+        $method = $class->getMethod('getUsernameFromProfileUrl');
+        $method->setAccessible(true);
+        $result =  $method->invokeArgs($this->listener, ['https://github.com/username']);
+
+        $this->assertSame('username', $result);
+    }
+
+    /**
+     * @return array
+     */
+    public function getEvents()
+    {
+        $user = new User();
+        $profile = new Hybrid_User_Profile();
+        $photoUrl = 'http://placehold.it/50x50';
+        $profile->photoURL = $photoUrl;
+        $profile->profileURL = 'https://github.com/username';
+
+        return [
+            [
+                new Event(null, null, [
+                    'user'        => $user,
+                    'userProfile' => $profile,
+                    'provider'    => 'github',
+                ]),
+                true, // expected event validity for LoginListener
+            ],
+            [
+                new Event(null, null, [
+                    'user'        => null,
+                    'userProfile' => $profile,
+                    'provider'    => 'github',
+                ]),
+                false,
+            ],
+            [
+                new Event(null, null, [
+                    'user'        => $user,
+                    'userProfile' => null,
+                    'provider'    => 'github',
+                ]),
+                false,
+            ],
+            [
+                new Event(null, null, [
+                    'user'        => $user,
+                    'userProfile' => $profile,
+                    'provider'    => 'invalid',
+                ]),
+                false,
+            ],
+            [
+                new Event(null, null, [
+                    'user'        => $user,
+                    'userProfile' => $profile,
+                ]),
+                false,
+            ],
+        ];
+    }
+}

--- a/module/User/test/UserTest/Integration/GitHub/LoginListenerTest.php
+++ b/module/User/test/UserTest/Integration/GitHub/LoginListenerTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace UserTest\Integration\GitHub;
+
+use ApplicationTest\Integration\Util\Bootstrap;
+use Hybrid_User_Profile;
+use PHPUnit_Framework_TestCase;
+use ReflectionClass;
+use ScnSocialAuth\Authentication\Adapter\HybridAuth;
+use User\GitHub\LoginListener;
+use User\Module;
+use Zend\EventManager\EventManager;
+use Zend\ModuleManager\ModuleManager;
+use Zend\Mvc\Application;
+use Zend\ServiceManager\ServiceManager;
+use Zend\Stdlib\CallbackHandler;
+
+/**
+ * Integration test case for {@see \User\GitHub\LoginListener}
+ *
+ * @coversNothing
+ */
+class LoginListenerTest extends PHPUnit_Framework_TestCase
+{
+    /** @var Application */
+    protected $application;
+
+    /** @var ModuleManager */
+    protected $moduleManager;
+
+    /** @var LoginListener */
+    protected $loginListener;
+
+    /** @var EventManager */
+    protected $eventManager;
+
+    protected function setUp()
+    {
+        $serviceManager      = $this->getServiceManager();
+        $this->application   = $serviceManager->get('Application');
+        $this->moduleManager = $serviceManager->get('ModuleManager');
+        $this->loginListener = $serviceManager->get('User\GitHub\LoginListener');
+        $this->eventManager  = $serviceManager->get('EventManager');
+    }
+
+    /**
+     * @return ServiceManager
+     */
+    protected function getServiceManager()
+    {
+        return Bootstrap::getServiceManager();
+    }
+
+    public function testEventListenerIsAttached()
+    {
+        /** @var Module $userModule */
+        $userModule = $this->moduleManager->loadModule('User');
+        $userModule->bootstrap($this->moduleManager, $this->application);
+
+        $listeners = $this->eventManager->getSharedManager()
+            ->getListeners('ScnSocialAuth\Authentication\Adapter\HybridAuth', 'registerViaProvider');
+
+        $this->assertFalse($listeners->isEmpty());
+
+        $attached = false;
+        $expectedCallback = [$this->loginListener, 'onRegister'];
+        /** @var CallbackHandler $listener */
+        foreach ($listeners as $listener) {
+            if ($listener->getCallback() === $expectedCallback) {
+                $attached = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($attached, '"User\GitHub\LoginListener::onRegister" is not attached');
+    }
+
+    /**
+     * Verifies that `registerViaProvider` event is triggered during registration process with GitHub account
+     * in ScnSocialAuth module as prevention against regression.
+     *
+     * @link https://github.com/zendframework/modules.zendframework.com/pull/286
+     */
+    public function testEventIsTriggered()
+    {
+        $serviceManager = $this->getServiceManager();
+        $eventManager = $this->getMockBuilder('Zend\EventManager\EventManagerInterface')->getMockForAbstractClass();
+        $eventManager->expects($this->atLeastOnce())
+            ->method('trigger')
+            ->will($this->returnValueMap([
+                ['registerViaProvider', null, null, null],
+            ]));
+        $mapper = $this->getMockBuilder('ZfcUser\Mapper\UserInterface')->getMockForAbstractClass();
+
+        $hybridAuth = new HybridAuth();
+        $hybridAuth->setEventManager($eventManager);
+        $hybridAuth->setServiceManager($serviceManager);
+        $hybridAuth->setZfcUserMapper($mapper);
+
+        $class = new ReflectionClass($hybridAuth);
+        $method = $class->getMethod('githubToLocalUser');
+        $method->setAccessible(true);
+        $method->invokeArgs($hybridAuth, [new Hybrid_User_Profile()]);
+    }
+}

--- a/module/User/test/UserTest/Integration/GitHub/LoginListenerTest.php
+++ b/module/User/test/UserTest/Integration/GitHub/LoginListenerTest.php
@@ -86,7 +86,7 @@ class LoginListenerTest extends PHPUnit_Framework_TestCase
         $triggered = false;
         $serviceManager = $this->getServiceManager();
         $eventManager = new EventManager();
-        $eventManager->attach('registerViaProvider', function ($e) use (&$triggered) {
+        $eventManager->attach('registerViaProvider', function () use (&$triggered) {
             $triggered = true;
         });
 

--- a/module/User/test/UserTest/Integration/GitHub/LoginListenerTest.php
+++ b/module/User/test/UserTest/Integration/GitHub/LoginListenerTest.php
@@ -83,13 +83,13 @@ class LoginListenerTest extends PHPUnit_Framework_TestCase
      */
     public function testEventIsTriggered()
     {
+        $triggered = false;
         $serviceManager = $this->getServiceManager();
-        $eventManager = $this->getMockBuilder('Zend\EventManager\EventManagerInterface')->getMockForAbstractClass();
-        $eventManager->expects($this->atLeastOnce())
-            ->method('trigger')
-            ->will($this->returnValueMap([
-                ['registerViaProvider', null, null, null],
-            ]));
+        $eventManager = new EventManager();
+        $eventManager->attach('registerViaProvider', function ($e) use (&$triggered) {
+            $triggered = true;
+        });
+
         $mapper = $this->getMockBuilder('ZfcUser\Mapper\UserInterface')->getMockForAbstractClass();
 
         $hybridAuth = new HybridAuth();
@@ -101,5 +101,7 @@ class LoginListenerTest extends PHPUnit_Framework_TestCase
         $method = $class->getMethod('githubToLocalUser');
         $method->setAccessible(true);
         $method->invokeArgs($hybridAuth, [new Hybrid_User_Profile()]);
+
+        $this->assertTrue($triggered);
     }
 }


### PR DESCRIPTION
As promised in #286 this PR moves registration listener from closure in `User\Module` to separate listener class. There is both unit and integration test case to assure that listener is attached and `registerViaProvider` event triggered in `ScnSocialAuth` module.

I still have to find a way how to update existing local user profile from actual GitHub data after login.

@Ocramius could you please provide code review?