### PR TITLE
Fix: Remove duplicate entry in array of modules

### DIFF
--- a/config/application.config.php
+++ b/config/application.config.php
@@ -3,7 +3,6 @@ ini_set('display_errors', 1);
 
 return array(
     'modules' => array(
-        'Application',
         'ZF\DevelopmentMode',
         'AssetManager',
         'ZfcBase',


### PR DESCRIPTION
The `Application` module is registered a few lines further down the line again, once should be enough.