### PR TITLE
Enhancement: Leverage class keyword as service identifiers for controllers

### DIFF
--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -6,6 +6,7 @@
  * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
+use Application\Controller;
 use Application\Service;
 use Application\View;
 use Psr\Log;
@@ -18,7 +19,7 @@ return [
                 'options' => [
                     'route'    => '/live-search',
                     'defaults' => [
-                        'controller' => 'Application\Controller\Search',
+                        'controller' => Controller\SearchController::class,
                         'action'     => 'index',
                     ],
                 ],
@@ -28,7 +29,7 @@ return [
                 'options' => [
                     'route'    => '/',
                     'defaults' => [
-                        'controller' => 'Application\Controller\Index',
+                        'controller' => Controller\IndexController::class,
                         'action'     => 'index',
                     ],
                 ],
@@ -40,7 +41,7 @@ return [
                 'options' => [
                     'route' => '/feed',
                     'defaults' => [
-                        'controller' => 'Application\Controller\Index',
+                        'controller' => Controller\IndexController::class,
                         'action' => 'feed',
                     ],
                 ],
@@ -80,8 +81,8 @@ return [
     ],
     'controllers' => [
         'factories' => [
-            'Application\Controller\Index' => 'Application\Controller\IndexControllerFactory',
-            'Application\Controller\Search' => 'Application\Controller\SearchControllerFactory',
+            Controller\IndexController::class => Controller\IndexControllerFactory::class,
+            Controller\SearchController::class => Controller\SearchControllerFactory::class,
         ],
     ],
     'service_manager' => [

--- a/module/Application/test/ApplicationTest/Integration/Controller/IndexControllerTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Controller/IndexControllerTest.php
@@ -80,7 +80,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         $this->dispatch('/');
 
-        $this->assertControllerName('Application\Controller\Index');
+        $this->assertControllerName(Controller\IndexController::class);
         $this->assertActionName('index');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
     }
@@ -112,7 +112,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         $this->dispatch('/feed');
 
-        $this->assertControllerName('Application\Controller\Index');
+        $this->assertControllerName(Controller\IndexController::class);
         $this->assertActionName('feed');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
     }

--- a/module/Application/test/ApplicationTest/Integration/Controller/SearchControllerTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Controller/SearchControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace ApplicationTest\Integration\Controller;
 
+use Application\Controller;
 use ApplicationTest\Integration\Util\Bootstrap;
 use Zend\Http;
 use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
@@ -37,7 +38,7 @@ class SearchControllerTest extends AbstractHttpControllerTestCase
 
         $this->dispatch('/live-search');
 
-        $this->assertControllerName('Application\Controller\Search');
+        $this->assertControllerName(Controller\SearchController::class);
         $this->assertActionName('index');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
     }

--- a/module/ZfModule/config/module.config.php
+++ b/module/ZfModule/config/module.config.php
@@ -1,6 +1,7 @@
 <?php
 
 use EdpGithub\Client;
+use ZfModule\Controller;
 use ZfModule\Delegators\EdpGithubClientAuthenticator;
 use ZfModule\Mapper\ModuleHydrator;
 use ZfModule\View\Helper;
@@ -8,7 +9,7 @@ use ZfModule\View\Helper;
 return [
     'controllers'  => [
         'factories' => [
-            'ZfModule\Controller\Index' => 'ZfModule\Controller\IndexControllerFactory',
+            Controller\IndexController::class => Controller\IndexControllerFactory::class,
         ],
     ],
     'router'       => [
@@ -18,7 +19,7 @@ return [
                 'options' => [
                     'route'    => '/:vendor/:module',
                     'defaults' => [
-                        'controller' => 'ZfModule\Controller\Index',
+                        'controller' => Controller\IndexController::class,
                         'action'     => 'view',
                     ],
                 ],
@@ -28,7 +29,7 @@ return [
                 'options'       => [
                     'route'    => '/module',
                     'defaults' => [
-                        'controller' => 'ZfModule\Controller\Index',
+                        'controller' => Controller\IndexController::class,
                         'action'     => 'index',
                     ],
                 ],

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -22,7 +22,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
     {
         $this->dispatch('/module');
 
-        $this->assertControllerName('ZfModule\Controller\Index');
+        $this->assertControllerName(Controller\IndexController::class);
         $this->assertActionName('index');
     }
 
@@ -37,7 +37,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         $this->dispatch($url);
 
-        $this->assertControllerName('ZfModule\Controller\Index');
+        $this->assertControllerName(Controller\IndexController::class);
         $this->assertActionName('organization');
     }
 
@@ -93,7 +93,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         $this->dispatch($url);
 
-        $this->assertControllerName('ZfModule\Controller\Index');
+        $this->assertControllerName(Controller\IndexController::class);
         $this->assertActionName('view');
     }
 }

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace ZfModuleTest\Integration\Controller;
+
+use Application\Service;
+use ApplicationTest\Integration\Util\Bootstrap;
+use stdClass;
+use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
+use ZfModule\Controller;
+use ZfModule\Mapper;
+
+class IndexControllerTest extends AbstractHttpControllerTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->setApplicationConfig(Bootstrap::getConfig());
+    }
+
+    public function testIndexActionCanBeAccessed()
+    {
+        $this->dispatch('/module');
+
+        $this->assertControllerName('ZfModule\Controller\Index');
+        $this->assertActionName('index');
+    }
+
+    public function testOrganizationActionCanBeAccessed()
+    {
+        $owner = 'foo';
+
+        $url = sprintf(
+            '/module/list/%s',
+            $owner
+        );
+
+        $this->dispatch($url);
+
+        $this->assertControllerName('ZfModule\Controller\Index');
+        $this->assertActionName('organization');
+    }
+
+    public function testViewActionCanBeAccessed()
+    {
+        $vendor = 'foo';
+        $module = 'bar';
+
+        $moduleMapper = $this->getMockBuilder(Mapper\Module::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $moduleMapper
+            ->expects($this->once())
+            ->method('findByName')
+            ->with($this->equalTo($module))
+            ->willReturn(new stdClass())
+        ;
+
+        $repositoryRetriever = $this->getMockBuilder(Service\RepositoryRetriever::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $repositoryRetriever
+            ->expects($this->once())
+            ->method('getUserRepositoryMetadata')
+            ->with(
+                $this->equalTo($vendor),
+                $this->equalTo($module)
+            )
+            ->willReturn(new stdClass())
+        ;
+
+        $this->getApplicationServiceLocator()
+            ->setAllowOverride(true)
+            ->setService(
+                'zfmodule_mapper_module',
+                $moduleMapper
+            )
+            ->setService(
+                Service\RepositoryRetriever::class,
+                $repositoryRetriever
+            )
+        ;
+
+        $url = sprintf(
+            '/%s/%s',
+            $vendor,
+            $module
+        );
+
+        $this->dispatch($url);
+
+        $this->assertControllerName('ZfModule\Controller\Index');
+        $this->assertActionName('view');
+    }
+}


### PR DESCRIPTION
I think I accidentally the whole thing.

This PR

* [x] leverages the `class` keyword for controller service identifiers in the `Application` module
* [x] adds basic integration tests for controllers in the `ZfModule`
* [x] leverages the `class` keyword for controller service identifiers in the `ZfModule` module

Related to #294.