### PR TITLE
Drop AssetManager module from dev-mode

### DIFF
--- a/config/development.config.php.dist
+++ b/config/development.config.php.dist
@@ -9,7 +9,6 @@ return [
     'modules' => [
         'ZendDeveloperTools',
         'ZFTool',
-        'AssetManager',
     ],
     // development time configuration globbing
     'module_listener_options' => [


### PR DESCRIPTION
Drop AssetManager module from dev-mode modules as it's loaded already in application.config.php