### PR TITLE
List of repositories from Github

### DIFF
--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -136,10 +136,6 @@ class IndexController extends AbstractActionController
                 return false;
             }
 
-            if (!$this->moduleService->isModule($repository)) {
-                return false;
-            }
-
             if ($this->moduleMapper->findByName($repository->name)) {
                 return false;
             }

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -120,15 +120,8 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         ;
 
         $moduleService
-            ->expects($this->any())
+            ->expects($this->never())
             ->method('isModule')
-            ->willReturnCallback(function ($repository) use ($nonModule) {
-                if ($repository !== $nonModule) {
-                    return true;
-                }
-
-                return false;
-            })
         ;
 
         $moduleMapper = $this->getMockBuilder(Mapper\Module::class)

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -280,18 +280,15 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
     }
 
-    public function testOrganizationActionRendersValidModulesOnly()
+    public function testOrganizationActionRendersUnregisteredModulesOnly()
     {
         $this->authenticatedAs(new User());
 
-        $validModule = $this->validModule();
-
-        $nonModule = $this->nonModule();
+        $unregisteredModule = $this->validModule();
         $registeredModule = $this->registeredModule();
 
         $repositories = [
-            $validModule,
-            $nonModule,
+            $unregisteredModule,
             $registeredModule,
             $this->forkedModule(),
             $this->moduleWithoutPushPermissions(),
@@ -318,15 +315,8 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         ;
 
         $moduleService
-            ->expects($this->any())
+            ->expects($this->never())
             ->method('isModule')
-            ->willReturnCallback(function ($repository) use ($nonModule) {
-                if ($repository !== $nonModule) {
-                    return true;
-                }
-
-                return false;
-            })
         ;
 
         $moduleMapper = $this->getMockBuilder(Mapper\Module::class)
@@ -382,8 +372,8 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $viewVariable = $viewModel->getVariable('repositories');
 
         $this->assertInternalType('array', $viewVariable);
-        $this->assertCount(2, $viewVariable);
-        $this->assertSame($validModule, $viewVariable[0]);
+        $this->assertCount(1, $viewVariable);
+        $this->assertSame($unregisteredModule, $viewVariable[0]);
     }
 
     public function testAddActionRedirectsIfNotAuthenticated()

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -179,7 +179,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $viewVariable = $viewModel->getVariable('repositories');
 
         $this->assertInternalType('array', $viewVariable);
-        $this->assertCount(1, $viewVariable);
+        $this->assertCount(2, $viewVariable);
         $this->assertSame($validModule, $viewVariable[0]);
     }
 
@@ -392,7 +392,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $viewVariable = $viewModel->getVariable('repositories');
 
         $this->assertInternalType('array', $viewVariable);
-        $this->assertCount(1, $viewVariable);
+        $this->assertCount(2, $viewVariable);
         $this->assertSame($validModule, $viewVariable[0]);
     }
 

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -84,21 +84,18 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
     }
 
-    public function testIndexActionRendersValidModulesOnly()
+    public function testIndexActionRendersUnregisteredModulesOnly()
     {
         $this->authenticatedAs(new User());
 
-        $validModule = $this->validModule();
-
-        $nonModule = $this->nonModule();
+        $unregisteredModule = $this->validModule();
         $registeredModule = $this->registeredModule();
 
         $repositories = [
-            $validModule,
-            $nonModule,
+            $unregisteredModule,
             $registeredModule,
-            $this->forkedModule(),
             $this->moduleWithoutPushPermissions(),
+            $this->forkedModule(),
         ];
 
         $repositoryCollection = $this->repositoryCollectionMock($repositories);
@@ -172,8 +169,8 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $viewVariable = $viewModel->getVariable('repositories');
 
         $this->assertInternalType('array', $viewVariable);
-        $this->assertCount(2, $viewVariable);
-        $this->assertSame($validModule, $viewVariable[0]);
+        $this->assertCount(1, $viewVariable);
+        $this->assertSame($unregisteredModule, $viewVariable[0]);
     }
 
     public function testOrganizationActionRedirectsIfNotAuthenticated()

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -116,11 +116,6 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
             ->getMock()
         ;
 
-        $moduleService
-            ->expects($this->never())
-            ->method('isModule')
-        ;
-
         $moduleMapper = $this->getMockBuilder(Mapper\Module::class)
             ->disableOriginalConstructor()
             ->getMock()
@@ -312,11 +307,6 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $moduleService = $this->getMockBuilder(Service\Module::class)
             ->disableOriginalConstructor()
             ->getMock()
-        ;
-
-        $moduleService
-            ->expects($this->never())
-            ->method('isModule')
         ;
 
         $moduleMapper = $this->getMockBuilder(Mapper\Module::class)


### PR DESCRIPTION
Hi! This proposal is not a resolution of all problems but in this moment I think that there are only one target..
We make zf.modules usable..
Login, submit repos in the first step.. This proposal tries to "resolve" the rate limit problem.

See
* #349 

With this PR the list of repos is inconsistente because there are a lot of repos wrong (not zf2 modules).. But works and if you try to submit a wrong repo exists a check for that :smile: 

Now there are already problem if i try to submit a good module I have this expection
`Statement could not be executed (23000 - 1048 - Column 'module_id' cannot be null)`

But I don't remember the story of the `module_id` :calendar: 

This isn't the final resolution :) 