### PR TITLE
Fix: Remove phpmd/phmd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ before_script:
 
 script:
   - vendor/bin/phpcs --standard=phpcs.xml -np --report=summary .
-#  - vendor/bin/phpmd . text codesize,unusedcode --exclude data,puphpet,vendor
   - vendor/bin/phpunit --configuration phpunit.xml
 
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
         "ezyang/htmlpurifier": "4.6.*"
     },
     "require-dev": {
-        "phpmd/phpmd": "~2.1",
         "phpunit/phpunit": "4.0.*",
         "bjyoungblood/BjyProfiler": "1.1.0",
         "squizlabs/php_codesniffer": "~2.0.0@RC",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "6c6ee070580d6eaa02d5a7e61a8aa7d2",
+    "hash": "e7694403873a47d57c097399ad55e68b",
     "packages": [
         {
             "name": "bshaffer/oauth2-server-php",
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/bshaffer/oauth2-server-php.git",
-                "reference": "bb254d3352aade23fcdf29e36399b51e485b072a"
+                "reference": "5ebe653d58a7f988de657ffdd39a305373787e12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bshaffer/oauth2-server-php/zipball/bb254d3352aade23fcdf29e36399b51e485b072a",
-                "reference": "bb254d3352aade23fcdf29e36399b51e485b072a",
+                "url": "https://api.github.com/repos/bshaffer/oauth2-server-php/zipball/5ebe653d58a7f988de657ffdd39a305373787e12",
+                "reference": "5ebe653d58a7f988de657ffdd39a305373787e12",
                 "shasum": ""
             },
             "require": {
@@ -52,7 +52,7 @@
                 "oauth",
                 "oauth2"
             ],
-            "time": "2015-01-19 22:57:38"
+            "time": "2015-01-27 18:14:56"
         },
         {
             "name": "evandotpro/edp-github",
@@ -114,49 +114,6 @@
                 "zf2"
             ],
             "time": "2014-09-18 10:51:10"
-        },
-        {
-            "name": "evandotpro/edp-markdown",
-            "version": "0.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/EvanDotPro/EdpMarkdown.git",
-                "reference": "5ec8b6f54efb99814b0bf9fbcc7523f970334c8d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/EvanDotPro/EdpMarkdown/zipball/5ec8b6f54efb99814b0bf9fbcc7523f970334c8d",
-                "reference": "5ec8b6f54efb99814b0bf9fbcc7523f970334c8d",
-                "shasum": ""
-            },
-            "require": {
-                "michelf/php-markdown": "~1.4",
-                "zendframework/zend-view": "2.*"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "Module.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Evan Coury",
-                    "email": "me@evancoury.com",
-                    "homepage": "http://blog.evan.pro/"
-                }
-            ],
-            "description": "A minimalist ZF2 module for adding markdown support to Zend Framework 2 projects",
-            "homepage": "https://github.com/EvanDotPro/EdpMarkdown",
-            "keywords": [
-                "ZendFramework",
-                "markdown"
-            ],
-            "time": "2014-04-16 12:04:03"
         },
         {
             "name": "evandotpro/edp-module-layouts",
@@ -360,57 +317,6 @@
                 "minification"
             ],
             "time": "2014-12-12 05:37:00"
-        },
-        {
-            "name": "michelf/php-markdown",
-            "version": "1.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/michelf/php-markdown.git",
-                "reference": "de9a19c7bf352d41cc99ed86c3c0ef17e87394b6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/michelf/php-markdown/zipball/de9a19c7bf352d41cc99ed86c3c0ef17e87394b6",
-                "reference": "de9a19c7bf352d41cc99ed86c3c0ef17e87394b6",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-lib": "1.4.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-0": {
-                    "Michelf": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Michel Fortin",
-                    "email": "michel.fortin@michelf.ca",
-                    "homepage": "http://michelf.ca/",
-                    "role": "Developer"
-                },
-                {
-                    "name": "John Gruber",
-                    "homepage": "http://daringfireball.net/"
-                }
-            ],
-            "description": "PHP Markdown",
-            "homepage": "http://michelf.ca/projects/php-markdown/",
-            "keywords": [
-                "markdown"
-            ],
-            "time": "2014-05-05 02:43:50"
         },
         {
             "name": "rwoverdijk/assetmanager",
@@ -1016,43 +922,6 @@
             ],
             "description": "Official version of pdepend to be handled with Composer",
             "time": "2014-12-04 12:38:39"
-        },
-        {
-            "name": "phpmd/phpmd",
-            "version": "2.1.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpmd/phpmd.git",
-                "reference": "1a485d9db869137af5e9678bd844568c92998b25"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/1a485d9db869137af5e9678bd844568c92998b25",
-                "reference": "1a485d9db869137af5e9678bd844568c92998b25",
-                "shasum": ""
-            },
-            "require": {
-                "pdepend/pdepend": "2.0.*",
-                "php": ">=5.3.0",
-                "symfony/config": "2.5.*",
-                "symfony/dependency-injection": "2.5.*",
-                "symfony/filesystem": "2.5.*"
-            },
-            "bin": [
-                "src/bin/phpmd"
-            ],
-            "type": "library",
-            "autoload": {
-                "psr-0": {
-                    "PHPMD\\": "src/main/php"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Official version of PHPMD handled with Composer.",
-            "time": "2014-09-25 15:56:22"
         },
         {
             "name": "phpunit/php-code-coverage",


### PR DESCRIPTION
Since there seems to be some consensus on removing `phpmd/phpmd`, this PR removes it.