### PR TITLE
Enhancement: Use Monolog logger with RotatingFileHandler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,23 +4,24 @@
     "license": "BSD-3-Clause",
     "homepage": "https://modules.zendframework.com",
     "require": {
-        "php": "~5.5",
         "bshaffer/oauth2-server-php": "dev-develop",
-        "zendframework/zendframework": "~2.3.0",
-        "rwoverdijk/assetmanager": "1.3.*",
         "evandotpro/edp-github": "dev-master",
         "evandotpro/edp-module-layouts": "1.0.*",
-        "zf-commons/zfc-user": "1.0.*",
-        "zfcampus/zf-development-mode": "~2.0",
+        "ezyang/htmlpurifier": "4.6.*",
+        "monolog/monolog": "~1.12",
+        "php": "~5.5",
+        "rwoverdijk/assetmanager": "1.3.*",
         "socalnick/scn-social-auth": "1.14.1",
-        "ezyang/htmlpurifier": "4.6.*"
+        "zendframework/zendframework": "~2.3.0",
+        "zf-commons/zfc-user": "1.0.*",
+        "zfcampus/zf-development-mode": "~2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.0.*",
         "bjyoungblood/BjyProfiler": "1.1.0",
+        "phpunit/phpunit": "4.0.*",
         "squizlabs/php_codesniffer": "~2.0.0@RC",
-        "zendframework/zftool": "dev-master",
-        "zendframework/zend-developer-tools": "dev-master"
+        "zendframework/zend-developer-tools": "dev-master",
+        "zendframework/zftool": "dev-master"
     },
     "autoload": {
         "psr-0": {
@@ -41,4 +42,3 @@
         }
     }
 }
-

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e7694403873a47d57c097399ad55e68b",
+    "hash": "131820a2caedb5952a2d50ac5ff65a28",
     "packages": [
         {
             "name": "bshaffer/oauth2-server-php",
@@ -317,6 +317,116 @@
                 "minification"
             ],
             "time": "2014-12-12 05:37:00"
+        },
+        {
+            "name": "monolog/monolog",
+            "version": "1.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/monolog.git",
+                "reference": "1fbe8c2641f2b163addf49cc5e18f144bec6b19f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/1fbe8c2641f2b163addf49cc5e18f144bec6b19f",
+                "reference": "1fbe8c2641f2b163addf49cc5e18f144bec6b19f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "psr/log": "~1.0"
+            },
+            "provide": {
+                "psr/log-implementation": "1.0.0"
+            },
+            "require-dev": {
+                "aws/aws-sdk-php": "~2.4, >2.4.8",
+                "doctrine/couchdb": "~1.0@dev",
+                "graylog2/gelf-php": "~1.0",
+                "phpunit/phpunit": "~4.0",
+                "raven/raven": "~0.5",
+                "ruflin/elastica": "0.90.*",
+                "videlalvaro/php-amqplib": "~2.4"
+            },
+            "suggest": {
+                "aws/aws-sdk-php": "Allow sending log messages to AWS services like DynamoDB",
+                "doctrine/couchdb": "Allow sending log messages to a CouchDB server",
+                "ext-amqp": "Allow sending log messages to an AMQP server (1.0+ required)",
+                "ext-mongo": "Allow sending log messages to a MongoDB server",
+                "graylog2/gelf-php": "Allow sending log messages to a GrayLog2 server",
+                "raven/raven": "Allow sending log messages to a Sentry server",
+                "rollbar/rollbar": "Allow sending log messages to Rollbar",
+                "ruflin/elastica": "Allow sending log messages to an Elastic Search server",
+                "videlalvaro/php-amqplib": "Allow sending log messages to an AMQP server using php-amqplib"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.12.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Monolog\\": "src/Monolog"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "Sends your logs to files, sockets, inboxes, databases and various web services",
+            "homepage": "http://github.com/Seldaek/monolog",
+            "keywords": [
+                "log",
+                "logging",
+                "psr-3"
+            ],
+            "time": "2014-12-29 21:29:35"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "reference": "fe0936ee26643249e916849d48e3a51d5f5e278b",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Psr\\Log\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2012-12-21 11:40:51"
         },
         {
             "name": "rwoverdijk/assetmanager",
@@ -1955,8 +2065,8 @@
         "bshaffer/oauth2-server-php": 20,
         "evandotpro/edp-github": 20,
         "squizlabs/php_codesniffer": 5,
-        "zendframework/zftool": 20,
-        "zendframework/zend-developer-tools": 20
+        "zendframework/zend-developer-tools": 20,
+        "zendframework/zftool": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -9,6 +9,7 @@
 
 use Application\Service;
 use Application\View;
+use Psr\Log;
 
 return [
     'router' => [
@@ -87,8 +88,10 @@ return [
     'service_manager' => [
         'factories' => [
             'translator' => 'Zend\I18n\Translator\TranslatorServiceFactory',
-            Service\RepositoryRetriever::class => Service\RepositoryRetrieverFactory::class,
             \HTMLPurifier::class => Service\HtmlPurifierFactory::class,
+            Log\LoggerInterface::class => Service\LoggerFactory::class,
+            Service\ErrorHandlingService::class => Service\ErrorHandlingServiceFactory::class,
+            Service\RepositoryRetriever::class => Service\RepositoryRetrieverFactory::class,
         ],
     ],
     'translator' => [

--- a/module/Application/src/Application/Module.php
+++ b/module/Application/src/Application/Module.php
@@ -9,12 +9,8 @@
 
 namespace Application;
 
-use Psr\Log\LoggerInterface;
-use Zend\Log\Logger;
-use Zend\Log\Writer\Stream;
 use Zend\Mvc\ModuleRouteListener;
 use Zend\Mvc\MvcEvent;
-use Zend\ServiceManager\ServiceManager;
 
 class Module
 {
@@ -33,16 +29,6 @@ class Module
                 $service->logException($exception);
             }
         });
-    }
-
-    public function getServiceConfig()
-    {
-        return [
-            'factories' => [
-                Service\ErrorHandlingService::class => Service\ErrorHandlingServiceFactory::class,
-                LoggerInterface::class => Service\LoggerFactory::class,
-            ],
-        ];
     }
 
     public function getConfig()

--- a/module/Application/src/Application/Module.php
+++ b/module/Application/src/Application/Module.php
@@ -39,10 +39,9 @@ class Module
     {
         return [
             'factories' => [
-                Service\ErrorHandlingService::class => function (ServiceManager $sm) {
-                    $logger  = $sm->get('ZendLog');
-                    $service = new ErrorHandlingService($logger);
-                    return $service;
+                Service\ErrorHandlingService::class => function (ServiceManager $serviceManager) {
+                    $logger  = $serviceManager->get('ZendLog');
+                    return new ErrorHandlingService($logger);
                 },
                 'ZendLog'                         => function (ServiceManager $sm) {
                     $filename = 'log_' . date('F') . '.txt';

--- a/module/Application/src/Application/Module.php
+++ b/module/Application/src/Application/Module.php
@@ -41,13 +41,6 @@ class Module
             'factories' => [
                 Service\ErrorHandlingService::class => Service\ErrorHandlingServiceFactory::class,
                 LoggerInterface::class => Service\LoggerFactory::class,
-                'ZendLog'                         => function (ServiceManager $sm) {
-                    $filename = 'log_' . date('F') . '.txt';
-                    $log      = new Logger();
-                    $writer   = new Stream('./data/logs/' . $filename);
-                    $log->addWriter($writer);
-                    return $log;
-                },
             ],
         ];
     }

--- a/module/Application/src/Application/Module.php
+++ b/module/Application/src/Application/Module.php
@@ -29,7 +29,7 @@ class Module
             $exception = $event->getResult()->exception;
             if ($exception) {
                 $sm      = $event->getApplication()->getServiceManager();
-                $service = $sm->get('ApplicationServiceErrorHandling');
+                $service = $sm->get(Service\ErrorHandlingService::class);
                 $service->logException($exception);
             }
         });
@@ -39,7 +39,7 @@ class Module
     {
         return [
             'factories' => [
-                'ApplicationServiceErrorHandling' => function (ServiceManager $sm) {
+                Service\ErrorHandlingService::class => function (ServiceManager $sm) {
                     $logger  = $sm->get('ZendLog');
                     $service = new ErrorHandlingService($logger);
                     return $service;

--- a/module/Application/src/Application/Module.php
+++ b/module/Application/src/Application/Module.php
@@ -9,7 +9,6 @@
 
 namespace Application;
 
-use Application\Service\ErrorHandlingService;
 use Zend\Log\Logger;
 use Zend\Log\Writer\Stream;
 use Zend\Mvc\ModuleRouteListener;
@@ -39,10 +38,7 @@ class Module
     {
         return [
             'factories' => [
-                Service\ErrorHandlingService::class => function (ServiceManager $serviceManager) {
-                    $logger  = $serviceManager->get('ZendLog');
-                    return new ErrorHandlingService($logger);
-                },
+                Service\ErrorHandlingService::class => Service\ErrorHandlingServiceFactory::class,
                 'ZendLog'                         => function (ServiceManager $sm) {
                     $filename = 'log_' . date('F') . '.txt';
                     $log      = new Logger();

--- a/module/Application/src/Application/Module.php
+++ b/module/Application/src/Application/Module.php
@@ -9,6 +9,7 @@
 
 namespace Application;
 
+use Psr\Log\LoggerInterface;
 use Zend\Log\Logger;
 use Zend\Log\Writer\Stream;
 use Zend\Mvc\ModuleRouteListener;
@@ -39,6 +40,7 @@ class Module
         return [
             'factories' => [
                 Service\ErrorHandlingService::class => Service\ErrorHandlingServiceFactory::class,
+                LoggerInterface::class => Service\LoggerFactory::class,
                 'ZendLog'                         => function (ServiceManager $sm) {
                     $filename = 'log_' . date('F') . '.txt';
                     $log      = new Logger();

--- a/module/Application/src/Application/Service/ErrorHandlingService.php
+++ b/module/Application/src/Application/Service/ErrorHandlingService.php
@@ -1,9 +1,4 @@
 <?php
-/**
- * Created by Gary Hockin.
- * Date: 04/12/14
- * @GeeH
- */
 
 namespace Application\Service;
 
@@ -11,11 +6,10 @@ use Zend\Log\Logger;
 
 class ErrorHandlingService
 {
-
     /**
      * @var Logger
      */
-    protected $logger;
+    private $logger;
 
     public function __construct(Logger $logger)
     {

--- a/module/Application/src/Application/Service/ErrorHandlingService.php
+++ b/module/Application/src/Application/Service/ErrorHandlingService.php
@@ -2,6 +2,7 @@
 
 namespace Application\Service;
 
+use Exception;
 use Psr\Log\LoggerInterface;
 
 class ErrorHandlingService
@@ -16,11 +17,29 @@ class ErrorHandlingService
         $this->logger = $logger;
     }
 
-    public function logException(\Exception $exception)
+    public function logException(Exception $exception)
     {
         $this->logger->error(
             $exception->getMessage(),
-            $exception->getTrace()
+            [
+                'previous' => $this->previousExceptionMessages($exception),
+                'trace' => $exception->getTrace(),
+            ]
         );
+    }
+
+    /**
+     * @param Exception $exception
+     * @return array
+     */
+    private function previousExceptionMessages(Exception $exception)
+    {
+        $messages = [];
+
+        while ($exception = $exception->getPrevious()) {
+            $messages[] = $exception->getMessage();
+        }
+
+        return $messages;
     }
 }

--- a/module/Application/src/Application/Service/ErrorHandlingService.php
+++ b/module/Application/src/Application/Service/ErrorHandlingService.php
@@ -16,17 +16,11 @@ class ErrorHandlingService
         $this->logger = $logger;
     }
 
-    public function logException(\Exception $e)
+    public function logException(\Exception $exception)
     {
-        $trace = $e->getTraceAsString();
-        $i     = 1;
-        do {
-            $messages[] = $i++ . ": " . $e->getMessage();
-        } while ($e = $e->getPrevious());
-
-        $log = "Exception:n" . implode("n", $messages);
-        $log .= "nTrace:n" . $trace;
-
-        $this->logger->error($log);
+        $this->logger->error(
+            $exception->getMessage(),
+            $exception->getTrace()
+        );
     }
 }

--- a/module/Application/src/Application/Service/ErrorHandlingService.php
+++ b/module/Application/src/Application/Service/ErrorHandlingService.php
@@ -2,16 +2,16 @@
 
 namespace Application\Service;
 
-use Zend\Log\Logger;
+use Psr\Log\LoggerInterface;
 
 class ErrorHandlingService
 {
     /**
-     * @var Logger
+     * @var LoggerInterface
      */
     private $logger;
 
-    public function __construct(Logger $logger)
+    public function __construct(LoggerInterface $logger)
     {
         $this->logger = $logger;
     }
@@ -27,6 +27,6 @@ class ErrorHandlingService
         $log = "Exception:n" . implode("n", $messages);
         $log .= "nTrace:n" . $trace;
 
-        $this->logger->err($log);
+        $this->logger->error($log);
     }
 }

--- a/module/Application/src/Application/Service/ErrorHandlingServiceFactory.php
+++ b/module/Application/src/Application/Service/ErrorHandlingServiceFactory.php
@@ -2,7 +2,7 @@
 
 namespace Application\Service;
 
-use Zend\Log;
+use Psr\Log\LoggerInterface;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -14,8 +14,8 @@ class ErrorHandlingServiceFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        /** @var Log\Logger $logger */
-        $logger  = $serviceLocator->get('ZendLog');
+        /* @var LoggerInterface $logger */
+        $logger  = $serviceLocator->get(LoggerInterface::class);
 
         return new ErrorHandlingService($logger);
     }

--- a/module/Application/src/Application/Service/ErrorHandlingServiceFactory.php
+++ b/module/Application/src/Application/Service/ErrorHandlingServiceFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Application\Service;
+
+use Zend\Log;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class ErrorHandlingServiceFactory implements FactoryInterface
+{
+    /**
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return ErrorHandlingService
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        /** @var Log\Logger $logger */
+        $logger  = $serviceLocator->get('ZendLog');
+
+        return new ErrorHandlingService($logger);
+    }
+}

--- a/module/Application/src/Application/Service/LoggerFactory.php
+++ b/module/Application/src/Application/Service/LoggerFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Application\Service;
+
+use Monolog\Logger;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class LoggerFactory implements FactoryInterface
+{
+    /**
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return Logger
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return new Logger('error-handling');
+    }
+}

--- a/module/Application/src/Application/Service/LoggerFactory.php
+++ b/module/Application/src/Application/Service/LoggerFactory.php
@@ -2,6 +2,7 @@
 
 namespace Application\Service;
 
+use Monolog\Handler;
 use Monolog\Logger;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
@@ -14,6 +15,11 @@ class LoggerFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return new Logger('error-handling');
+        $handler = new Handler\RotatingFileHandler('data/logs/error.log');
+
+        $logger = new Logger('error-handling');
+        $logger->pushHandler($handler);
+
+        return $logger;
     }
 }

--- a/module/Application/src/Application/Service/LoggerFactory.php
+++ b/module/Application/src/Application/Service/LoggerFactory.php
@@ -16,10 +16,6 @@ class LoggerFactory implements FactoryInterface
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         $handler = new Handler\RotatingFileHandler('data/logs/error.log');
-        $handler->setFilenameFormat(
-            '{filename}-{date}',
-            'Y-m'
-        );
 
         $logger = new Logger('error-handling');
         $logger->pushHandler($handler);

--- a/module/Application/src/Application/Service/LoggerFactory.php
+++ b/module/Application/src/Application/Service/LoggerFactory.php
@@ -15,10 +15,10 @@ class LoggerFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $handler = new Handler\RotatingFileHandler('data/logs/log.txt');
+        $handler = new Handler\RotatingFileHandler('data/logs/error.log');
         $handler->setFilenameFormat(
-            '{filename}_{date}',
-            'F'
+            '{filename}-{date}',
+            'Y-m'
         );
 
         $logger = new Logger('error-handling');

--- a/module/Application/src/Application/Service/LoggerFactory.php
+++ b/module/Application/src/Application/Service/LoggerFactory.php
@@ -15,7 +15,11 @@ class LoggerFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $handler = new Handler\RotatingFileHandler('data/logs/error.log');
+        $handler = new Handler\RotatingFileHandler('data/logs/log.txt');
+        $handler->setFilenameFormat(
+            '{filename}_{date}',
+            'F'
+        );
 
         $logger = new Logger('error-handling');
         $logger->pushHandler($handler);

--- a/module/Application/test/ApplicationTest/Integration/Service/ErrorHandlingServiceTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Service/ErrorHandlingServiceTest.php
@@ -6,6 +6,9 @@ use Application\Service;
 use ApplicationTest\Integration\Util\Bootstrap;
 use PHPUnit_Framework_TestCase;
 
+/**
+ * @covers Application\Service\ErrorHandlingService
+ */
 class ErrorHandlingServiceTest extends PHPUnit_Framework_TestCase
 {
     public function testServiceCanBeRetrieved()

--- a/module/Application/test/ApplicationTest/Integration/Service/ErrorHandlingServiceTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Service/ErrorHandlingServiceTest.php
@@ -2,18 +2,19 @@
 
 namespace ApplicationTest\Integration\Service;
 
+use Application\Service;
 use ApplicationTest\Integration\Util\Bootstrap;
 use PHPUnit_Framework_TestCase;
 
-class HtmlPurifierTest extends PHPUnit_Framework_TestCase
+class ErrorHandlingServiceTest extends PHPUnit_Framework_TestCase
 {
     public function testServiceCanBeRetrieved()
     {
         $serviceManager = Bootstrap::getServiceManager();
 
         $this->assertInstanceOf(
-            \HTMLPurifier::class,
-            $serviceManager->get(\HTMLPurifier::class)
+            Service\ErrorHandlingService::class,
+            $serviceManager->get(Service\ErrorHandlingService::class)
         );
     }
 }

--- a/module/Application/test/ApplicationTest/Integration/Service/ErrorHandlingServiceTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Service/ErrorHandlingServiceTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ApplicationTest\Integration\Service;
+
+use ApplicationTest\Integration\Util\Bootstrap;
+use PHPUnit_Framework_TestCase;
+
+class HtmlPurifierTest extends PHPUnit_Framework_TestCase
+{
+    public function testServiceCanBeRetrieved()
+    {
+        $serviceManager = Bootstrap::getServiceManager();
+
+        $this->assertInstanceOf(
+            \HTMLPurifier::class,
+            $serviceManager->get(\HTMLPurifier::class)
+        );
+    }
+}

--- a/module/Application/test/ApplicationTest/Integration/Service/ErrorHandlingServiceTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Service/ErrorHandlingServiceTest.php
@@ -7,7 +7,8 @@ use ApplicationTest\Integration\Util\Bootstrap;
 use PHPUnit_Framework_TestCase;
 
 /**
- * @covers Application\Service\ErrorHandlingService
+ * @group Functional
+ * @coversNothing
  */
 class ErrorHandlingServiceTest extends PHPUnit_Framework_TestCase
 {

--- a/module/Application/test/ApplicationTest/Integration/Service/LoggerFactoryTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Service/LoggerFactoryTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace ApplicationTest\Integration\Service;
+
+use Application\Service;
+use ApplicationTest\Integration\Util\Bootstrap;
+use Psr\Log;
+use PHPUnit_Framework_TestCase;
+
+class LoggerFactoryTest extends PHPUnit_Framework_TestCase
+{
+    public function testServiceCanBeRetrieved()
+    {
+        $serviceManager = Bootstrap::getServiceManager();
+
+        $this->assertInstanceOf(
+            Log\LoggerInterface::class,
+            $serviceManager->get(Log\LoggerInterface::class)
+        );
+    }
+}

--- a/module/Application/test/ApplicationTest/Integration/Service/LoggerFactoryTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Service/LoggerFactoryTest.php
@@ -9,6 +9,10 @@ use Monolog\Logger;
 use Psr\Log;
 use PHPUnit_Framework_TestCase;
 
+/**
+ * @group Functional
+ * @coversNothing
+ */
 class LoggerFactoryTest extends PHPUnit_Framework_TestCase
 {
     /**

--- a/module/Application/test/ApplicationTest/Integration/Service/LoggerFactoryTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Service/LoggerFactoryTest.php
@@ -4,18 +4,47 @@ namespace ApplicationTest\Integration\Service;
 
 use Application\Service;
 use ApplicationTest\Integration\Util\Bootstrap;
+use Monolog\Handler;
+use Monolog\Logger;
 use Psr\Log;
 use PHPUnit_Framework_TestCase;
 
 class LoggerFactoryTest extends PHPUnit_Framework_TestCase
 {
-    public function testServiceCanBeRetrieved()
+    /**
+     * @var Logger
+     */
+    private $service;
+
+    protected function setUp()
     {
         $serviceManager = Bootstrap::getServiceManager();
 
-        $this->assertInstanceOf(
-            Log\LoggerInterface::class,
-            $serviceManager->get(Log\LoggerInterface::class)
-        );
+        $this->service = $serviceManager->get(Log\LoggerInterface::class);
+    }
+
+    public function testIsMonologLogger()
+    {
+        $this->assertInstanceOf(Logger::class, $this->service);
+    }
+
+    public function testName()
+    {
+        $this->assertSame('error-handling', $this->service->getName());
+    }
+
+    public function testHasRotatingHandler()
+    {
+        $handlers = $this->service->getHandlers();
+
+        $hasRotatingFileHandler = false;
+
+        array_walk($handlers, function ($handler) use (&$hasRotatingFileHandler) {
+            if ($handler instanceof Handler\RotatingFileHandler) {
+                $hasRotatingFileHandler = true;
+            };
+        });
+
+        $this->assertTrue($hasRotatingFileHandler);
     }
 }

--- a/module/Application/test/ApplicationTest/Service/ErrorHandlingServiceTest.php
+++ b/module/Application/test/ApplicationTest/Service/ErrorHandlingServiceTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ApplicationTest\Service;
+
+use Application\Service;
+use Exception;
+use PHPUnit_Framework_TestCase;
+use Zend\Log;
+
+class ErrorHandlingServiceTest extends PHPUnit_Framework_TestCase
+{
+    public function testLogExceptionLogsSomething()
+    {
+        $exception = new Exception('Why, hello!');
+
+        $logger = $this->getMockBuilder(Log\Logger::class)->getMock();
+        $logger
+            ->expects($this->once())
+            ->method('err')
+            ->with($this->stringContains($exception->getMessage()))
+        ;
+
+        $service = new Service\ErrorHandlingService($logger);
+        $service->logException($exception);
+    }
+}

--- a/module/Application/test/ApplicationTest/Service/ErrorHandlingServiceTest.php
+++ b/module/Application/test/ApplicationTest/Service/ErrorHandlingServiceTest.php
@@ -5,7 +5,7 @@ namespace ApplicationTest\Service;
 use Application\Service;
 use Exception;
 use PHPUnit_Framework_TestCase;
-use Zend\Log;
+use Psr\Log\LoggerInterface;
 
 class ErrorHandlingServiceTest extends PHPUnit_Framework_TestCase
 {
@@ -13,10 +13,10 @@ class ErrorHandlingServiceTest extends PHPUnit_Framework_TestCase
     {
         $exception = new Exception('Why, hello!');
 
-        $logger = $this->getMockBuilder(Log\Logger::class)->getMock();
+        $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
         $logger
             ->expects($this->once())
-            ->method('err')
+            ->method('error')
             ->with($this->stringContains($exception->getMessage()))
         ;
 

--- a/module/Application/test/ApplicationTest/Service/ErrorHandlingServiceTest.php
+++ b/module/Application/test/ApplicationTest/Service/ErrorHandlingServiceTest.php
@@ -12,7 +12,7 @@ use Psr\Log\LoggerInterface;
  */
 class ErrorHandlingServiceTest extends PHPUnit_Framework_TestCase
 {
-    public function testLogExceptionLogsSomething()
+    public function testLogExceptionLogsExceptionWithTrace()
     {
         $exception = new Exception('Why, hello!');
 
@@ -22,11 +22,40 @@ class ErrorHandlingServiceTest extends PHPUnit_Framework_TestCase
             ->method('error')
             ->with(
                 $this->equalTo($exception->getMessage()),
-                $this->equalTo($exception->getTrace())
+                $this->equalTo([
+                    'previous' => [],
+                    'trace' => $exception->getTrace(),
+                ])
             )
         ;
 
         $service = new Service\ErrorHandlingService($logger);
         $service->logException($exception);
+    }
+
+    public function testLogExceptionLogsExceptionWithPreviousExceptionTrace()
+    {
+        $a = new Exception('Oh noes');
+        $b = new Exception('What have I done?!', 0, $a);
+        $c = new Exception('This is hard', 0, $b);
+
+        $logger = $this->getMockBuilder(LoggerInterface::class)->getMock();
+        $logger
+            ->expects($this->once())
+            ->method('error')
+            ->with(
+                $this->equalTo($c->getMessage()),
+                $this->equalTo([
+                    'previous' => [
+                        $b->getMessage(),
+                        $a->getMessage(),
+                    ],
+                    'trace' => $c->getTrace(),
+                ])
+            )
+        ;
+
+        $service = new Service\ErrorHandlingService($logger);
+        $service->logException($c);
     }
 }

--- a/module/Application/test/ApplicationTest/Service/ErrorHandlingServiceTest.php
+++ b/module/Application/test/ApplicationTest/Service/ErrorHandlingServiceTest.php
@@ -7,6 +7,9 @@ use Exception;
 use PHPUnit_Framework_TestCase;
 use Psr\Log\LoggerInterface;
 
+/**
+ * @covers Application\Service\ErrorHandlingService
+ */
 class ErrorHandlingServiceTest extends PHPUnit_Framework_TestCase
 {
     public function testLogExceptionLogsSomething()
@@ -17,7 +20,10 @@ class ErrorHandlingServiceTest extends PHPUnit_Framework_TestCase
         $logger
             ->expects($this->once())
             ->method('error')
-            ->with($this->stringContains($exception->getMessage()))
+            ->with(
+                $this->equalTo($exception->getMessage()),
+                $this->equalTo($exception->getTrace())
+            )
         ;
 
         $service = new Service\ErrorHandlingService($logger);


### PR DESCRIPTION
This PR

* [x] asserts `Service\ErrorHandlingService` actually logs something
* [x] asserts `Service\ErrorHandlingService` can be created
* [x] uses class name as service identifier for `Service\ErrorHandlingService` 
* [x] extracts a concrete factory for `Service\ErrorHandlingService` 
* [x] requires `monolog/monolog`
* [x] creates a factory for a PSR-3 logger
* [x] feeds a `Monolog\Logger` with attached `Monolog\Handler\RotatingFileHandler` to `Service\ErrorHandlingService`
* [x] moves service configuration to `module.config.php`
* [x] improves logging by passing in exception message as log message, stack trace as context

Replaces #336.