### PR TITLE
Fix: Wording of message in case no modules have been submitted

### DIFF
--- a/module/User/view/zfc-user/user/index.phtml
+++ b/module/User/view/zfc-user/user/index.phtml
@@ -25,7 +25,7 @@
                 <?php
                 if (empty($modules)) {
                     ?>
-                    <div class="alert alert-block">No modules was submitted yet</div>
+                    <div class="alert alert-block">No modules have been submitted yet</div>
                     <?php
                 }
                 foreach ($modules as $module) {


### PR DESCRIPTION
This PR

* [x] fixes the style of the message displayed when no modules have been submitted yet

Compare `No modules was submitted yet` to `No modules have been submitted yet`.