### PR TITLE
Fix: Remove useless files

### DIFF
--- a/module/Application/Module.php
+++ b/module/Application/Module.php
@@ -1,9 +1,0 @@
-<?php
-/**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/ZendSkeletonModule for the canonical source repository
- * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
- */
-require_once __DIR__ . '/src/Application/Module.php';

--- a/module/User/Module.php
+++ b/module/User/Module.php
@@ -1,9 +1,0 @@
-<?php
-/**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/ZendSkeletonModule for the canonical source repository
- * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
- */
-require_once __DIR__ . '/src/User/Module.php';

--- a/module/ZfModule/Module.php
+++ b/module/ZfModule/Module.php
@@ -1,9 +1,0 @@
-<?php
-/**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/ZendSkeletonModule for the canonical source repository
- * @copyright Copyright (c) 2005-2012 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
- */
-require_once __DIR__ . '/src/ZfModule/Module.php';


### PR DESCRIPTION
This PR

* [x] removes leftovers from previous ZF2 versions module loading mechanism

Follows @Ocramius' comment, see [`Zend\ModuleManager\Listener\ModuleResolverListener`](https://github.com/zendframework/zf2/blob/master/library/Zend/ModuleManager/Listener/ModuleResolverListener.php#L23-L34).

Not sure when this was changed?!