### PR TITLE
Fix: Remove useless configuration

### DIFF
--- a/module/User/config/module.config.php
+++ b/module/User/config/module.config.php
@@ -16,11 +16,6 @@ return [
             __DIR__ . '/../view',
         ],
     ],
-    'controllers' => [
-        'invokables' => [
-            'User\Controller\Module' => 'User\Controller\ModuleController',
-        ],
-    ],
     'view_helpers' => [
         'factories' => [
             'newUsers' => 'User\View\Helper\NewUsersFactory',


### PR DESCRIPTION
This PR

* [x] removes controller manager configuration which is useless, as a `User\Controller\ModuleController` doesn't even exist