### PR TITLE
Fix: View helper should actually be a controller plugin

### DIFF
--- a/module/User/config/module.config.php
+++ b/module/User/config/module.config.php
@@ -1,8 +1,14 @@
 <?php
 
+use User\Controller;
 use User\GitHub;
 
 return [
+    'controllers' => [
+        'invokables' => [
+            'zfcuser' => Controller\UserController::class,
+        ],
+    ],
     'view_manager' => [
         'template_map' => [
             'helper/module'                 =>  __DIR__ . '/../view/helper/module.phtml',

--- a/module/User/src/User/Controller/UserController.php
+++ b/module/User/src/User/Controller/UserController.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace User\Controller;
+
+use Zend\View\Model\ViewModel;
+use ZfcUser\Controller\Plugin\ZfcUserAuthentication;
+use ZfcUser\Controller\UserController as ZfcUserController;
+
+/**
+ * @method array listModule(array $options)
+ * @method ZfcUserAuthentication zfcUserAuthentication()
+ */
+class UserController extends ZfcUserController
+{
+    public function indexAction()
+    {
+        if (!$this->zfcUserAuthentication()->hasIdentity()) {
+            return $this->redirect()->toRoute(static::ROUTE_LOGIN);
+        }
+
+        $viewModel = new ViewModel([
+            'modules' => $this->listModule([
+                'user' => true,
+            ]),
+        ]);
+
+        $viewModel->setTemplate('zfc-user/user/index');
+
+        return $viewModel;
+    }
+}

--- a/module/User/test/UserTest/Integration/Controller/UserControllerTest.php
+++ b/module/User/test/UserTest/Integration/Controller/UserControllerTest.php
@@ -3,9 +3,16 @@
 namespace UserTest\Integration\Controller;
 
 use ApplicationTest\Integration\Util\Bootstrap;
+use User\Controller;
+use User\Entity\User;
+use User\View\Helper\UserOrganizations;
 use Zend\Authentication\AuthenticationService;
 use Zend\Http;
+use Zend\Mvc;
 use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
+use Zend\View;
+use ZfModule\Mvc\Controller\Plugin\ListModule;
+use ZfModule\View\Helper\TotalModules;
 
 /**
  * @coversNothing
@@ -46,5 +53,103 @@ class UserControllerTest extends AbstractHttpControllerTestCase
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_302);
 
         $this->assertRedirectTo('/user/login');
+    }
+
+    public function testIndexActionSetsModulesIfAuthenticated()
+    {
+        $authenticationService = $this->getMockBuilder(AuthenticationService::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $authenticationService
+            ->expects($this->any())
+            ->method('hasIdentity')
+            ->willReturn(true)
+        ;
+
+        $authenticationService
+            ->expects($this->any())
+            ->method('getIdentity')
+            ->willReturn(new User())
+        ;
+
+        $serviceManager = $this->getApplicationServiceLocator();
+
+        $serviceManager
+            ->setAllowOverride(true)
+            ->setService(
+                'zfcuser_auth_service',
+                $authenticationService
+            )
+        ;
+
+        $listModule = $this->getMockBuilder(ListModule::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $listModule
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($this->equalTo([
+                'user' => true,
+            ]))
+            ->willReturn([])
+        ;
+
+        /* @var Mvc\Controller\PluginManager $controllerPluginManager */
+        $controllerPluginManager = $serviceManager->get('ControllerPluginManager');
+
+        $controllerPluginManager
+            ->setAllowOverride(true)
+            ->setService(
+                'listModule',
+                $listModule
+            )
+        ;
+
+        $userOrganizations = $this->getMockBuilder(UserOrganizations::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $userOrganizations
+            ->expects($this->any())
+            ->method('__invoke')
+            ->willReturn('foo')
+        ;
+
+        $totalModules = $this->getMockBuilder(TotalModules::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $totalModules
+            ->expects($this->any())
+            ->method('__invoke')
+            ->willReturn('foo')
+        ;
+
+        /* @var View\HelperPluginManager $viewHelperManager */
+        $viewHelperManager = $serviceManager->get('ViewHelperManager');
+
+        $viewHelperManager
+            ->setAllowOverride(true)
+            ->setService(
+                'userOrganizations',
+                $userOrganizations
+            )
+            ->setService(
+                'totalModules',
+                $totalModules
+            )
+        ;
+
+        $this->dispatch('/user');
+
+        $this->assertControllerName('zfcuser');
+        $this->assertActionName('index');
+        $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
     }
 }

--- a/module/User/test/UserTest/Integration/Controller/UserControllerTest.php
+++ b/module/User/test/UserTest/Integration/Controller/UserControllerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace UserTest\Integration\Controller;
+
+use ApplicationTest\Integration\Util\Bootstrap;
+use Zend\Authentication\AuthenticationService;
+use Zend\Http;
+use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
+
+/**
+ * @coversNothing
+ */
+class UserControllerTest extends AbstractHttpControllerTestCase
+{
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->setApplicationConfig(Bootstrap::getConfig());
+    }
+
+    public function testIndexActionRedirectsIfNotAuthenticated()
+    {
+        $authenticationService = $this->getMockBuilder(AuthenticationService::class)->getMock();
+
+        $authenticationService
+            ->expects($this->once())
+            ->method('hasIdentity')
+            ->willReturn(false)
+        ;
+
+        $serviceManager = $this->getApplicationServiceLocator();
+
+        $serviceManager
+            ->setAllowOverride(true)
+            ->setService(
+                'zfcuser_auth_service',
+                $authenticationService
+            )
+        ;
+
+        $this->dispatch('/user');
+
+        $this->assertControllerName('zfcuser');
+        $this->assertActionName('index');
+        $this->assertResponseStatusCode(Http\Response::STATUS_CODE_302);
+
+        $this->assertRedirectTo('/user/login');
+    }
+}

--- a/module/User/view/zfc-user/user/index.phtml
+++ b/module/User/view/zfc-user/user/index.phtml
@@ -23,7 +23,6 @@
         <div class="tab-content">
             <div class="tab-pane active" id="modules">
                 <?php
-                $modules = $this->listModule(['user' => true]);
                 if (empty($modules)) {
                     ?>
                     <div class="alert alert-block">No modules was submitted yet</div>

--- a/module/ZfModule/config/module.config.php
+++ b/module/ZfModule/config/module.config.php
@@ -4,9 +4,15 @@ use EdpGithub\Client;
 use ZfModule\Controller;
 use ZfModule\Delegators\EdpGithubClientAuthenticator;
 use ZfModule\Mapper\ModuleHydrator;
+use ZfModule\Mvc;
 use ZfModule\View\Helper;
 
 return [
+    'controller_plugins' => [
+        'factories' => [
+            'listModule' => Mvc\Controller\Plugin\ListModuleFactory::class,
+        ],
+    ],
     'controllers'  => [
         'factories' => [
             Controller\IndexController::class => Controller\IndexControllerFactory::class,
@@ -76,7 +82,6 @@ return [
     ],
     'view_helpers' => [
         'factories'  => [
-            'listModule'   => Helper\ListModuleFactory::class,
             'newModule'    => Helper\NewModuleFactory::class,
             'totalModules' => Helper\TotalModulesFactory::class,
         ],

--- a/module/ZfModule/src/ZfModule/Mvc/Controller/Plugin/ListModule.php
+++ b/module/ZfModule/src/ZfModule/Mvc/Controller/Plugin/ListModule.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace ZfModule\View\Helper;
+namespace ZfModule\Mvc\Controller\Plugin;
 
 use EdpGithub\Client;
-use Zend\View\Helper\AbstractHelper;
+use Zend\Mvc\Controller\Plugin\AbstractPlugin;
 use ZfModule\Mapper;
 
-class ListModule extends AbstractHelper
+class ListModule extends AbstractPlugin
 {
     /**
      * @var Mapper\Module

--- a/module/ZfModule/src/ZfModule/Mvc/Controller/Plugin/ListModuleFactory.php
+++ b/module/ZfModule/src/ZfModule/Mvc/Controller/Plugin/ListModuleFactory.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace ZfModule\View\Helper;
+namespace ZfModule\Mvc\Controller\Plugin;
 
 use EdpGithub\Client;
+use Zend\Mvc\Controller\PluginManager;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
-use Zend\View\HelperPluginManager;
 use ZfModule\Mapper;
 
 class ListModuleFactory implements FactoryInterface
@@ -15,10 +15,10 @@ class ListModuleFactory implements FactoryInterface
      *
      * @return ListModule
      */
-    public function createService(ServiceLocatorInterface $helperPluginManager)
+    public function createService(ServiceLocatorInterface $pluginManager)
     {
-        /* @var HelperPluginManager $helperPluginManager */
-        $serviceManager = $helperPluginManager->getServiceLocator();
+        /* @var PluginManager $pluginManager */
+        $serviceManager = $pluginManager->getServiceLocator();
 
         /* @var Mapper\Module $moduleMapper */
         $moduleMapper = $serviceManager->get('zfmodule_mapper_module');


### PR DESCRIPTION
This PR

* [x] turns a view helper which should be a controller plugin into a controller plugin
* [x] implements an extension of the `ZfcUser\Controller\UserController` in order to set view variables in the view model returned from the `indexAction()`