### PR TITLE
Fix: Remove PHPMD annotations

### DIFF
--- a/module/User/src/User/Module.php
+++ b/module/User/src/User/Module.php
@@ -10,8 +10,6 @@ use ZfcBase\Module\AbstractModule;
 class Module extends AbstractModule
 {
     /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     *
      * @param ModuleManager $moduleManager
      * @param ApplicationInterface $app
      */

--- a/module/ZfModule/src/ZfModule/Mapper/Module.php
+++ b/module/ZfModule/src/ZfModule/Mapper/Module.php
@@ -87,9 +87,6 @@ class Module extends AbstractDbMapper implements ModuleInterface
         return $entity;
     }
 
-    /**
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     */
     public function findByOwner($owner, $limit = null, $orderBy = null, $sort = 'ASC')
     {
         $select = $this->getSelect();


### PR DESCRIPTION
This PR

* [x] removes useless suppressions of PHPMD warnings

Follows #354.