### PR TITLE
Fix: Misspelled method is actually used

### DIFF
--- a/module/Application/view/application/index/index.phtml
+++ b/module/Application/view/application/index/index.phtml
@@ -15,6 +15,7 @@
             </div>
         </div>
         <?php foreach ($this->repositories as $module): ?>
+            <?php /* @var ZfModule\Entity\Module $module */ ?>
             <div class="row-fluid module-row">
                 <div class="span12">
                     <div class="row-fluid">
@@ -40,7 +41,7 @@
                                     </a>
                                 </strong>
                                 <p>
-                                    <span class="author-label">Created:</span> <?php echo $module->getCreateAtDateTime()->format('Y-m-d') ?><br>
+                                    <span class="author-label">Created:</span> <?php echo $module->getCreatedAtDateTime()->format('Y-m-d') ?><br>
                                 </p>
                             </div>
                             <div style="clear: both;"></div>


### PR DESCRIPTION
This PR

* [x] fixes an issue where a misspelled method `getCreateAtDateTime()` was actually used

Follows #366.