### PR TITLE
Fix: Pass repository instead of array into view helper

### DIFF
--- a/module/ZfModule/src/ZfModule/View/Helper/ModuleDescription.php
+++ b/module/ZfModule/src/ZfModule/View/Helper/ModuleDescription.php
@@ -7,13 +7,18 @@ use Zend\View\Helper\AbstractHelper;
 class ModuleDescription extends AbstractHelper
 {
     /**
-     * @param array $module
+     * @param $repository
      * @return string
      */
-    public function __invoke(array $module)
+    public function __invoke($repository)
     {
         return $this->getView()->render('zf-module/helper/module-description.phtml', [
-            'module' => $module,
+            'owner' => $repository->owner->login,
+            'name' => $repository->name,
+            'createdAt' => $repository->created_at,
+            'url' => $repository->html_url,
+            'photoUrl' => $repository->owner->avatar_url,
+            'description' => $repository->description,
         ]);
     }
 }

--- a/module/ZfModule/test/ZfModuleTest/View/Helper/ModuleDescriptionTest.php
+++ b/module/ZfModule/test/ZfModuleTest/View/Helper/ModuleDescriptionTest.php
@@ -3,6 +3,7 @@
 namespace ZfModuleTest\View\Helper;
 
 use PHPUnit_Framework_TestCase;
+use stdClass;
 use Zend\View;
 use ZfModule\View\Helper;
 
@@ -10,9 +11,14 @@ class ModuleDescriptionTest extends PHPUnit_Framework_TestCase
 {
     public function testInvokeRendersViewScript()
     {
-        $module = [
-            'foo' => 'bar',
-        ];
+        $module = new stdClass();
+        $module->owner = new stdClass();
+        $module->owner->login = 'foo';
+        $module->owner->avatar_url = 'http://www.example.org/john.gif';
+        $module->name = 'bar';
+        $module->created_at = '1970-01-01 00:00:00';
+        $module->html_url = 'http://www.example.org';
+        $module->description = 'blah blah blah';
 
         $view = $this->getMockForAbstractClass(View\Renderer\RendererInterface::class);
 
@@ -22,7 +28,12 @@ class ModuleDescriptionTest extends PHPUnit_Framework_TestCase
             ->with(
                 $this->equalTo('zf-module/helper/module-description.phtml'),
                 $this->equalTo([
-                    'module' => $module,
+                    'owner' => $module->owner->login,
+                    'name' => $module->name,
+                    'createdAt' => $module->created_at,
+                    'url' => $module->html_url,
+                    'photoUrl' => $module->owner->avatar_url,
+                    'description' => $module->description,
                 ])
             )
         ;

--- a/module/ZfModule/view/zf-module/helper/module-description.phtml
+++ b/module/ZfModule/view/zf-module/helper/module-description.phtml
@@ -1,13 +1,13 @@
 <div class="row">
     <div class="hidden-xs col-sm-2">
-        <img src="<?php echo $this->escapeHtmlAttr($module['photo_url']) ?>" alt="<?php echo $this->escapeHtmlAttr($module['owner']) ?>" class="thumbnail img-responsive">
+        <img src="<?php echo $this->escapeHtmlAttr($this->photoUrl); ?>" alt="<?php echo $this->escapeHtmlAttr($this->owner); ?>" class="thumbnail img-responsive">
     </div>
     <div class="col-xs-7 col-sm-6">
-        <p><strong><?php echo $this->escapeHtml($module['name']) ?></strong></p>
-        <p><span class="zf-green">Submitter:</span> <?php echo $this->escapeHtml($module['owner']) ?></p>
-        <p><span class="zf-green">Created:</span> <?php echo $this->dateFormat(new DateTime($module['created_at']), IntlDateFormatter::SHORT, IntlDateFormatter::SHORT); ?></p>
+        <p><strong><?php echo $this->escapeHtml($this->name); ?></strong></p>
+        <p><span class="zf-green">Submitter:</span> <?php echo $this->escapeHtml($this->owner); ?></p>
+        <p><span class="zf-green">Created:</span> <?php echo $this->dateFormat(new DateTime($this->createdAt), IntlDateFormatter::SHORT, IntlDateFormatter::SHORT); ?></p>
     </div>
     <div class="col-xs-4">
-        <a href="<?php echo $this->escapeHtmlAttr($module['url']) ?>">Show module on GitHub</a>
+        <a href="<?php echo $this->escapeHtmlAttr($this->url); ?>">Show module on GitHub</a>
     </div>
 </div>

--- a/module/ZfModule/view/zf-module/index/view.phtml
+++ b/module/ZfModule/view/zf-module/index/view.phtml
@@ -38,14 +38,7 @@
     </div>
     <div class="col-md-4">
         <div class="sidebar">
-            <?php echo $this->moduleDescription([
-                'owner' => $repository->owner->login,
-                'name' => $repository->name,
-                'created_at' => $repository->created_at,
-                'url' => $repository->html_url,
-                'photo_url' => $repository->owner->avatar_url,
-                'description' => $repository->description
-            ]) ?>
+            <?php echo $this->moduleDescription($repository); ?>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This PR

* [x] passes a repository to the `ModuleDescription` view helper so it can decide itself what it needs, rather than passing a big 'ole array to it