### PR TITLE
Fix: Simplify rendering of view scripts in view helpers

### DIFF
--- a/module/User/src/User/View/Helper/NewUsers.php
+++ b/module/User/src/User/View/Helper/NewUsers.php
@@ -4,7 +4,6 @@ namespace User\View\Helper;
 
 use User\Mapper;
 use Zend\View\Helper\AbstractHelper;
-use Zend\View\Model\ViewModel;
 
 class NewUsers extends AbstractHelper
 {
@@ -36,12 +35,9 @@ class NewUsers extends AbstractHelper
     {
         $users = $this->userMapper->findAll(16, 'created_at', 'DESC');
 
-        $vm = new ViewModel([
+        return $this->getView()->render('user/helper/new-users', [
             'users' => $users,
         ]);
-        $vm->setTemplate('user/helper/new-users');
-
-        return $this->getView()->render($vm);
     }
 
     /**

--- a/module/User/src/User/View/Helper/NewUsers.php
+++ b/module/User/src/User/View/Helper/NewUsers.php
@@ -13,11 +13,6 @@ class NewUsers extends AbstractHelper
     private $userMapper;
 
     /**
-     * $var string template used for view
-     */
-    protected $viewTemplate;
-
-    /**
      * @param Mapper\User $userMapper
      */
     public function __construct(Mapper\User $userMapper)
@@ -38,16 +33,5 @@ class NewUsers extends AbstractHelper
         return $this->getView()->render('user/helper/new-users', [
             'users' => $users,
         ]);
-    }
-
-    /**
-     * @param string $viewTemplate
-     * @return NewUsers
-     */
-    public function setViewTemplate($viewTemplate)
-    {
-        $this->viewTemplate = $viewTemplate;
-
-        return $this;
     }
 }

--- a/module/User/src/User/View/Helper/UserOrganizations.php
+++ b/module/User/src/User/View/Helper/UserOrganizations.php
@@ -4,7 +4,6 @@ namespace User\View\Helper;
 
 use EdpGithub\Client;
 use Zend\View\Helper\AbstractHelper;
-use Zend\View\Model\ViewModel;
 
 class UserOrganizations extends AbstractHelper
 {
@@ -35,11 +34,9 @@ class UserOrganizations extends AbstractHelper
     public function __invoke()
     {
         $orgs = $this->githubClient->api('current_user')->orgs();
-        $vm = new ViewModel([
+
+        return $this->getView()->render('user/helper/user-organizations.phtml', [
             'orgs' => $orgs,
         ]);
-        $vm->setTemplate('user/helper/user-organizations.phtml');
-
-        return $this->getView()->render($vm);
     }
 }

--- a/module/User/test/UserTest/View/Helper/NewUsersTest.php
+++ b/module/User/test/UserTest/View/Helper/NewUsersTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace UserTest\View\Helper;
+
+use PHPUnit_Framework_TestCase;
+use User\Mapper;
+use User\View\Helper;
+use Zend\View;
+
+class NewUsersTest extends PHPUnit_Framework_TestCase
+{
+    public function testInvokeRendersViewScriptWith16MostRecentUsers()
+    {
+        $users = [
+            'Jane',
+            'Suzie',
+            'Jack',
+        ];
+
+        $userMapper = $this->getMockBuilder(Mapper\User::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $userMapper
+            ->expects($this->once())
+            ->method('findAll')
+            ->with(
+                $this->equalTo(16),
+                $this->equalTo('created_at'),
+                $this->equalTo('DESC')
+            )
+            ->willReturn($users)
+        ;
+
+        $view = $this->getMockBuilder(View\Renderer\RendererInterface::class)->getMock();
+
+        $view
+            ->expects($this->once())
+            ->method('render')
+            ->with(
+                $this->equalTo('user/helper/new-users'),
+                $this->equalTo([
+                    'users' => $users,
+                ])
+            )
+        ;
+
+        $helper = new Helper\NewUsers($userMapper);
+        $helper->setView($view);
+
+        $helper();
+    }
+}

--- a/module/User/test/UserTest/View/Helper/NewUsersTest.php
+++ b/module/User/test/UserTest/View/Helper/NewUsersTest.php
@@ -51,4 +51,32 @@ class NewUsersTest extends PHPUnit_Framework_TestCase
 
         $helper();
     }
+
+    public function testCanSetViewTemplate()
+    {
+        $viewTemplate = 'foo';
+
+        $userMapper = $this->getMockBuilder(Mapper\User::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $view = $this->getMockBuilder(View\Renderer\RendererInterface::class)->getMock();
+
+        $view
+            ->expects($this->once())
+            ->method('render')
+            ->with(
+                $this->equalTo($viewTemplate),
+                $this->equalTo([
+                    'users' => null,
+                ])
+            )
+        ;
+
+        $helper = new Helper\NewUsers($userMapper);
+        $helper->setView($view);
+
+        $helper();
+    }
 }

--- a/module/User/test/UserTest/View/Helper/NewUsersTest.php
+++ b/module/User/test/UserTest/View/Helper/NewUsersTest.php
@@ -51,32 +51,4 @@ class NewUsersTest extends PHPUnit_Framework_TestCase
 
         $helper();
     }
-
-    public function testCanSetViewTemplate()
-    {
-        $viewTemplate = 'foo';
-
-        $userMapper = $this->getMockBuilder(Mapper\User::class)
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-
-        $view = $this->getMockBuilder(View\Renderer\RendererInterface::class)->getMock();
-
-        $view
-            ->expects($this->once())
-            ->method('render')
-            ->with(
-                $this->equalTo($viewTemplate),
-                $this->equalTo([
-                    'users' => null,
-                ])
-            )
-        ;
-
-        $helper = new Helper\NewUsers($userMapper);
-        $helper->setView($view);
-
-        $helper();
-    }
 }

--- a/module/User/test/UserTest/View/Helper/UserOrganizationsTest.php
+++ b/module/User/test/UserTest/View/Helper/UserOrganizationsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace UserTest\View\Helper;
+
+use EdpGithub\Api;
+use EdpGithub\Client;
+use PHPUnit_Framework_TestCase;
+use User\View\Helper;
+use Zend\View;
+
+class UserOrganizationsTest extends PHPUnit_Framework_TestCase
+{
+    public function testInvokeRendersViewScriptWithUserOrganizations()
+    {
+        $organizations = [
+            'foo',
+            'bar',
+            'baz',
+        ];
+
+        $currentUserApi = $this->getMockBuilder(Api\CurrentUser::class)->getMock();
+
+        $currentUserApi
+            ->expects($this->once())
+            ->method('orgs')
+            ->willReturn($organizations)
+        ;
+
+        $githubClient = $this->getMockBuilder(Client::class)->getMock();
+
+        $githubClient
+            ->expects($this->once())
+            ->method('api')
+            ->with($this->equalTo('current_user'))
+            ->willReturn($currentUserApi)
+        ;
+
+        $view = $this->getMockBuilder(View\Renderer\RendererInterface::class)->getMock();
+
+        $view
+            ->expects($this->once())
+            ->method('render')
+            ->with(
+                $this->equalTo('user/helper/user-organizations.phtml'),
+                $this->equalTo([
+                    'orgs' => $organizations,
+                ])
+            )
+        ;
+
+        $helper = new Helper\UserOrganizations($githubClient);
+        $helper->setView($view);
+
+        $helper();
+    }
+}

--- a/module/ZfModule/src/ZfModule/View/Helper/ComposerView.php
+++ b/module/ZfModule/src/ZfModule/View/Helper/ComposerView.php
@@ -3,7 +3,6 @@
 namespace ZfModule\View\Helper;
 
 use Zend\View\Helper\AbstractHelper;
-use Zend\View\Model\ViewModel;
 
 class ComposerView extends AbstractHelper
 {
@@ -15,11 +14,8 @@ class ComposerView extends AbstractHelper
      */
     public function __invoke($composerConf)
     {
-        $vm = new ViewModel([
+        return $this->getView()->render('zf-module/helper/composer-view.phtml', [
             'composerConf' => json_decode($composerConf, true),
         ]);
-        $vm->setTemplate('zf-module/helper/composer-view.phtml');
-
-        return $this->getView()->render($vm);
     }
 }

--- a/module/ZfModule/src/ZfModule/View/Helper/ModuleDescription.php
+++ b/module/ZfModule/src/ZfModule/View/Helper/ModuleDescription.php
@@ -3,7 +3,6 @@
 namespace ZfModule\View\Helper;
 
 use Zend\View\Helper\AbstractHelper;
-use Zend\View\Model\ViewModel;
 
 class ModuleDescription extends AbstractHelper
 {
@@ -15,11 +14,8 @@ class ModuleDescription extends AbstractHelper
      */
     public function __invoke($module)
     {
-        $vm = new ViewModel([
+        return $this->getView()->render('zf-module/helper/module-description.phtml', [
             'module' => $module,
         ]);
-        $vm->setTemplate('zf-module/helper/module-description.phtml');
-
-        return $this->getView()->render($vm);
     }
 }

--- a/module/ZfModule/src/ZfModule/View/Helper/ModuleView.php
+++ b/module/ZfModule/src/ZfModule/View/Helper/ModuleView.php
@@ -3,7 +3,6 @@
 namespace ZfModule\View\Helper;
 
 use Zend\View\Helper\AbstractHelper;
-use Zend\View\Model\ViewModel;
 
 class ModuleView extends AbstractHelper
 {
@@ -15,12 +14,9 @@ class ModuleView extends AbstractHelper
      */
     public function __invoke($module, $button = 'submit')
     {
-        $vm = new ViewModel([
+        return $this->getView()->render('zf-module/helper/module-view.phtml', [
             'module' => $module,
             'button' => $button,
         ]);
-        $vm->setTemplate('zf-module/helper/module-view.phtml');
-
-        return $this->getView()->render($vm);
     }
 }

--- a/module/ZfModule/src/ZfModule/View/Helper/NewModule.php
+++ b/module/ZfModule/src/ZfModule/View/Helper/NewModule.php
@@ -3,7 +3,6 @@
 namespace ZfModule\View\Helper;
 
 use Zend\View\Helper\AbstractHelper;
-use Zend\View\Model\ViewModel;
 use ZfModule\Mapper;
 
 class NewModule extends AbstractHelper
@@ -28,12 +27,8 @@ class NewModule extends AbstractHelper
     {
         $modules = $this->moduleMapper->findAll(10, 'created_at', 'DESC');
 
-        //return $modules;
-        $vm = new ViewModel([
+        return $this->getView()->render('zf-module/helper/new-module', [
             'modules' => $modules,
         ]);
-        $vm->setTemplate('zf-module/helper/new-module');
-
-        return $this->getView()->render($vm);
     }
 }

--- a/module/ZfModule/src/ZfModule/View/Helper/TotalModules.php
+++ b/module/ZfModule/src/ZfModule/View/Helper/TotalModules.php
@@ -15,7 +15,7 @@ class TotalModules extends AbstractHelper
     /**
      * @var int
      */
-    protected $total;
+    private $total;
 
     /**
      * @param Mapper\Module $moduleMapper

--- a/module/ZfModule/test/ZfModuleTest/View/Helper/ComposerViewTest.php
+++ b/module/ZfModule/test/ZfModuleTest/View/Helper/ComposerViewTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace ZfModuleTest\View\Helper;
+
+use PHPUnit_Framework_TestCase;
+use Zend\View;
+use ZfModule\View\Helper;
+
+class ComposerViewTest extends PHPUnit_Framework_TestCase
+{
+    public function testInvokeRendersViewScript()
+    {
+        $composerConf = '{"foo":"bar"}';
+
+        $view = $this->getMockForAbstractClass(View\Renderer\RendererInterface::class);
+
+        $view
+            ->expects($this->once())
+            ->method('render')
+            ->with(
+                $this->equalTo('zf-module/helper/composer-view.phtml'),
+                $this->equalTo([
+                    'composerConf' => json_decode($composerConf, true),
+                ])
+            )
+        ;
+
+        $helper = new Helper\ComposerView();
+        $helper->setView($view);
+
+        $helper($composerConf);
+    }
+}

--- a/module/ZfModule/test/ZfModuleTest/View/Helper/ModuleDescriptionTest.php
+++ b/module/ZfModule/test/ZfModuleTest/View/Helper/ModuleDescriptionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace ZfModuleTest\View\Helper;
+
+use PHPUnit_Framework_TestCase;
+use Zend\View;
+use ZfModule\View\Helper;
+
+class ModuleDescriptionTest extends PHPUnit_Framework_TestCase
+{
+    public function testInvokeRendersViewScript()
+    {
+        $module = [
+            'foo' => 'bar',
+        ];
+
+        $view = $this->getMockForAbstractClass(View\Renderer\RendererInterface::class);
+
+        $view
+            ->expects($this->once())
+            ->method('render')
+            ->with(
+                $this->equalTo('zf-module/helper/module-description.phtml'),
+                $this->equalTo([
+                    'module' => $module,
+                ])
+            )
+        ;
+
+        $helper = new Helper\ModuleDescription();
+        $helper->setView($view);
+
+        $helper($module);
+    }
+}

--- a/module/ZfModule/test/ZfModuleTest/View/Helper/ModuleViewTest.php
+++ b/module/ZfModule/test/ZfModuleTest/View/Helper/ModuleViewTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace ZfModuleTest\View\Helper;
+
+use PHPUnit_Framework_TestCase;
+use Zend\View;
+use ZfModule\View\Helper;
+
+class ModuleViewTest extends PHPUnit_Framework_TestCase
+{
+    public function testInvokeRendersViewScript()
+    {
+        $module = [
+            'foo' => 'bar',
+        ];
+
+        $view = $this->getMockForAbstractClass(View\Renderer\RendererInterface::class);
+
+        $view
+            ->expects($this->once())
+            ->method('render')
+            ->with(
+                $this->equalTo('zf-module/helper/module-view.phtml'),
+                $this->equalTo([
+                    'module' => $module,
+                    'button' => 'submit',
+                ])
+            )
+        ;
+
+        $helper = new Helper\ModuleView();
+        $helper->setView($view);
+
+        $helper($module);
+    }
+
+    public function testInvokeAllowsSpecifyingButtonType()
+    {
+        $module = [
+            'foo' => 'bar',
+        ];
+
+        $button = 'baz';
+
+        $view = $this->getMockForAbstractClass(View\Renderer\RendererInterface::class);
+
+        $view
+            ->expects($this->once())
+            ->method('render')
+            ->with(
+                $this->equalTo('zf-module/helper/module-view.phtml'),
+                $this->equalTo([
+                    'module' => $module,
+                    'button' => $button,
+                ])
+            )
+        ;
+
+        $helper = new Helper\ModuleView();
+        $helper->setView($view);
+
+        $helper($module, $button);
+    }
+}

--- a/module/ZfModule/test/ZfModuleTest/View/Helper/NewModuleTest.php
+++ b/module/ZfModule/test/ZfModuleTest/View/Helper/NewModuleTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace ZfModuleTest\View\Helper;
+
+use PHPUnit_Framework_TestCase;
+use Zend\View;
+use ZfModule\Mapper;
+use ZfModule\View\Helper;
+
+class NewModuleTest extends PHPUnit_Framework_TestCase
+{
+    public function testInvokeRendersViewScriptWithTenMostRecentModules()
+    {
+        $modules = [
+            'foo',
+            'bar',
+            'baz',
+        ];
+
+        $moduleMapper = $this->getMockBuilder(Mapper\Module::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $moduleMapper
+            ->expects($this->once())
+            ->method('findAll')
+            ->with(
+                $this->equalTo(10),
+                $this->equalTo('created_at'),
+                $this->equalTo('DESC')
+            )
+            ->willReturn($modules)
+        ;
+
+        $view = $this->getMockForAbstractClass(View\Renderer\RendererInterface::class);
+
+        $view
+            ->expects($this->once())
+            ->method('render')
+            ->with(
+                $this->equalTo('zf-module/helper/new-module'),
+                $this->equalTo([
+                    'modules' => $modules,
+                ])
+            )
+        ;
+
+        $helper = new Helper\NewModule($moduleMapper);
+        $helper->setView($view);
+
+        $helper();
+    }
+}

--- a/module/ZfModule/test/ZfModuleTest/View/Helper/TotalModulesTest.php
+++ b/module/ZfModule/test/ZfModuleTest/View/Helper/TotalModulesTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace ZfModuleTest\View\Helper;
+
+use PHPUnit_Framework_TestCase;
+use ZfModule\Mapper;
+use ZfModule\View\Helper;
+
+class TotalModulesTest extends PHPUnit_Framework_TestCase
+{
+    public function testInvokeReturnsNumberOfTotalModules()
+    {
+        $totalModules = 9000;
+
+        $moduleMapper = $this->getMockBuilder(Mapper\Module::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $moduleMapper
+            ->expects($this->once())
+            ->method('getTotal')
+            ->willReturn($totalModules)
+        ;
+
+        $helper = new Helper\TotalModules($moduleMapper);
+
+        $this->assertSame($totalModules, $helper());
+    }
+}

--- a/module/ZfModule/test/ZfModuleTest/View/Helper/TotalModulesTest.php
+++ b/module/ZfModule/test/ZfModuleTest/View/Helper/TotalModulesTest.php
@@ -3,6 +3,7 @@
 namespace ZfModuleTest\View\Helper;
 
 use PHPUnit_Framework_TestCase;
+use ReflectionObject;
 use ZfModule\Mapper;
 use ZfModule\View\Helper;
 
@@ -24,6 +25,32 @@ class TotalModulesTest extends PHPUnit_Framework_TestCase
         ;
 
         $helper = new Helper\TotalModules($moduleMapper);
+
+        $this->assertSame($totalModules, $helper());
+    }
+
+    public function testInvokeDoesNotFetchTotalModulesWhenAlreadyFetched()
+    {
+        $totalModules = 9000;
+
+        $moduleMapper = $this->getMockBuilder(Mapper\Module::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $moduleMapper
+            ->expects($this->never())
+            ->method('getTotal')
+        ;
+
+        $helper = new Helper\TotalModules($moduleMapper);
+
+        $reflection = new ReflectionObject($helper);
+
+        $property = $reflection->getProperty('total');
+
+        $property->setAccessible(true);
+        $property->setValue($helper, $totalModules);
 
         $this->assertSame($totalModules, $helper());
     }


### PR DESCRIPTION
This PR

* [x] simplifies rendering in view helpers which more or less just pass through an array of values to a view script
* [x] adds tests for `User\View\Helper`
* [x] adds tests for `ZfModule\View\Helper`
* [x] removes code without effect