### PR TITLE
Fix: Clean up template maps

### DIFF
--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -118,13 +118,13 @@ return [
         'not_found_template'       => 'error/404',
         'exception_template'       => 'error/index',
         'template_map' => [
-            'layout/error'                      => __DIR__ . '/../view/layout/layout-small-header.phtml',
-            'layout/layout'                     => __DIR__ . '/../view/layout/layout.phtml',
             'application/index/index'           => __DIR__ . '/../view/application/index/index.phtml',
             'application/index/pagination'      => __DIR__ . '/../view/application/index/pagination.phtml',
+            'application/search/index'          => __DIR__ . '/../view/application/search/index.phtml',
+            'layout/error'                      => __DIR__ . '/../view/layout/layout-small-header.phtml',
+            'layout/layout'                     => __DIR__ . '/../view/layout/layout.phtml',
             'error/404'                         => __DIR__ . '/../view/error/404.phtml',
             'error/index'                       => __DIR__ . '/../view/error/index.phtml',
-            'application/search/index'          => __DIR__ . '/../view/application/search/index.phtml',
         ],
         'template_path_stack' => [
             __DIR__ . '/../view',

--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -124,7 +124,6 @@ return [
             'application/index/pagination'      => __DIR__ . '/../view/application/index/pagination.phtml',
             'error/404'                         => __DIR__ . '/../view/error/404.phtml',
             'error/index'                       => __DIR__ . '/../view/error/index.phtml',
-            'application/helper/new-modules'    => __DIR__ . '/../view/application/helper/new-modules.phtml',
             'application/search/index'          => __DIR__ . '/../view/application/search/index.phtml',
         ],
         'template_path_stack' => [

--- a/module/User/config/module.config.php
+++ b/module/User/config/module.config.php
@@ -14,11 +14,8 @@ return [
     ],
     'view_manager' => [
         'template_map' => [
-            'helper/module'                 =>  __DIR__ . '/../view/helper/module.phtml',
             'scn-social-auth/user/login'    =>  __DIR__ . '/../view/scn-social-auth/user/login.phtml',
             'user/helper/new-users'         =>  __DIR__ . '/../view/user/helper/new-users.phtml',
-            'user/module/orgs'              =>  __DIR__ . '/../view/user/module/orgs.phtml',
-            'user/module/repos'             =>  __DIR__ . '/../view/user/module/repos.phtml',
             'zfc-user/user/index'           =>  __DIR__ . '/../view/zfc-user/user/index.phtml',
         ],
         'template_path_stack' => [


### PR DESCRIPTION
This PR

* [x] removes non-existent templates from template maps
* [x] keeps remaining templates sorted by key