### PR TITLE
Fix: Directly attach to SharedEventManager instance

### DIFF
--- a/module/User/test/UserTest/GitHub/LoginListenerTest.php
+++ b/module/User/test/UserTest/GitHub/LoginListenerTest.php
@@ -8,7 +8,7 @@ use ReflectionClass;
 use User\Entity\User;
 use User\GitHub\LoginListener;
 use Zend\EventManager\Event;
-use Zend\EventManager\EventManager;
+use Zend\EventManager\SharedEventManager;
 
 /**
  * Test case for {@see \User\GitHub\LoginListener}
@@ -28,11 +28,14 @@ class LoginListenerTest extends PHPUnit_Framework_TestCase
      */
     public function testAttach()
     {
-        $eventManager = new EventManager();
-        $this->listener->attachShared($eventManager->getSharedManager());
+        $sharedEventManager = new SharedEventManager();
 
-        $listeners = $eventManager->getSharedManager()
-            ->getListeners('ScnSocialAuth\Authentication\Adapter\HybridAuth', 'registerViaProvider');
+        $this->listener->attachShared($sharedEventManager);
+
+        $listeners = $sharedEventManager->getListeners(
+            'ScnSocialAuth\Authentication\Adapter\HybridAuth',
+            'registerViaProvider'
+        );
 
         $this->assertFalse($listeners->isEmpty());
     }

--- a/module/User/test/UserTest/GitHub/LoginListenerTest.php
+++ b/module/User/test/UserTest/GitHub/LoginListenerTest.php
@@ -15,8 +15,10 @@ use Zend\EventManager\SharedEventManager;
  */
 class LoginListenerTest extends PHPUnit_Framework_TestCase
 {
-    /** @var LoginListener */
-    protected $listener;
+    /**
+     * @var LoginListener
+     */
+    private $listener;
 
     protected function setUp()
     {

--- a/module/User/test/UserTest/GitHub/LoginListenerTest.php
+++ b/module/User/test/UserTest/GitHub/LoginListenerTest.php
@@ -25,6 +25,11 @@ class LoginListenerTest extends PHPUnit_Framework_TestCase
         $this->listener = new LoginListener();
     }
 
+    protected function tearDown()
+    {
+        unset($this->listener);
+    }
+
     /**
      * @covers \User\GitHub\LoginListener::attachShared
      */


### PR DESCRIPTION
This PR

* [x] fixes a test by attaching to the `SharedEventManager` directly rather than attempting to retrieve it from an `EventManager`

Fixes #379. 