### PR TITLE
Enhancement: Clean up ZfModule\Controller\IndexController

### DIFF
--- a/module/Application/test/ApplicationTest/Integration/Util/AuthenticationTrait.php
+++ b/module/Application/test/ApplicationTest/Integration/Util/AuthenticationTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace ApplicationTest\Integration\Util;
+
+use PHPUnit_Framework_MockObject_Matcher_InvokedCount;
+use PHPUnit_Framework_MockObject_MockBuilder;
+use Zend\Authentication;
+use Zend\ServiceManager;
+
+/**
+ * @method ServiceManager\ServiceManager getApplicationServiceLocator
+ * @method PHPUnit_Framework_MockObject_MockBuilder getMockBuilder()
+ * @method PHPUnit_Framework_MockObject_Matcher_InvokedCount once()
+ */
+trait AuthenticationTrait
+{
+    protected function notAuthenticated()
+    {
+        $authenticationService = $this->getMockBuilder(Authentication\AuthenticationService::class)
+            ->getMock();
+
+        $authenticationService
+            ->expects($this->once())
+            ->method('hasIdentity')
+            ->willReturn(false);
+
+        $serviceManager = $this->getApplicationServiceLocator();
+
+        $serviceManager
+            ->setAllowOverride(true)
+            ->setService(
+                'zfcuser_auth_service',
+                $authenticationService
+            )
+        ;
+    }
+}

--- a/module/Application/test/ApplicationTest/Integration/Util/AuthenticationTrait.php
+++ b/module/Application/test/ApplicationTest/Integration/Util/AuthenticationTrait.php
@@ -2,16 +2,14 @@
 
 namespace ApplicationTest\Integration\Util;
 
-use PHPUnit_Framework_MockObject_Matcher_InvokedCount;
-use PHPUnit_Framework_MockObject_MockBuilder;
 use Zend\Authentication\AuthenticationService;
 use Zend\ServiceManager;
 
 /**
  * @method ServiceManager\ServiceManager getApplicationServiceLocator()
- * @method PHPUnit_Framework_MockObject_MockBuilder getMockBuilder()
- * @method PHPUnit_Framework_MockObject_Matcher_InvokedCount once()
- * @method PHPUnit_Framework_MockObject_Matcher_InvokedCount any()
+ * @method \PHPUnit_Framework_MockObject_MockBuilder getMockBuilder()
+ * @method \PHPUnit_Framework_MockObject_Matcher_InvokedCount once()
+ * @method \PHPUnit_Framework_MockObject_Matcher_InvokedCount any()
  */
 trait AuthenticationTrait
 {

--- a/module/Application/test/ApplicationTest/Integration/Util/AuthenticationTrait.php
+++ b/module/Application/test/ApplicationTest/Integration/Util/AuthenticationTrait.php
@@ -4,11 +4,11 @@ namespace ApplicationTest\Integration\Util;
 
 use PHPUnit_Framework_MockObject_Matcher_InvokedCount;
 use PHPUnit_Framework_MockObject_MockBuilder;
-use Zend\Authentication;
+use Zend\Authentication\AuthenticationService;
 use Zend\ServiceManager;
 
 /**
- * @method ServiceManager\ServiceManager getApplicationServiceLocator
+ * @method ServiceManager\ServiceManager getApplicationServiceLocator()
  * @method PHPUnit_Framework_MockObject_MockBuilder getMockBuilder()
  * @method PHPUnit_Framework_MockObject_Matcher_InvokedCount once()
  * @method PHPUnit_Framework_MockObject_Matcher_InvokedCount any()
@@ -17,8 +17,7 @@ trait AuthenticationTrait
 {
     protected function notAuthenticated()
     {
-        $authenticationService = $this->getMockBuilder(Authentication\AuthenticationService::class)
-            ->getMock();
+        $authenticationService = $this->getMockBuilder(AuthenticationService::class)->getMock();
 
         $authenticationService
             ->expects($this->once())
@@ -38,7 +37,7 @@ trait AuthenticationTrait
 
     protected function authenticatedAs($identity)
     {
-        $authenticationService = $this->getMockBuilder(Authentication\AuthenticationService::class)
+        $authenticationService = $this->getMockBuilder(AuthenticationService::class)
             ->disableOriginalConstructor()
             ->getMock()
         ;

--- a/module/Application/test/ApplicationTest/Integration/Util/AuthenticationTrait.php
+++ b/module/Application/test/ApplicationTest/Integration/Util/AuthenticationTrait.php
@@ -11,6 +11,7 @@ use Zend\ServiceManager;
  * @method ServiceManager\ServiceManager getApplicationServiceLocator
  * @method PHPUnit_Framework_MockObject_MockBuilder getMockBuilder()
  * @method PHPUnit_Framework_MockObject_Matcher_InvokedCount once()
+ * @method PHPUnit_Framework_MockObject_Matcher_InvokedCount any()
  */
 trait AuthenticationTrait
 {
@@ -23,6 +24,36 @@ trait AuthenticationTrait
             ->expects($this->once())
             ->method('hasIdentity')
             ->willReturn(false);
+
+        $serviceManager = $this->getApplicationServiceLocator();
+
+        $serviceManager
+            ->setAllowOverride(true)
+            ->setService(
+                'zfcuser_auth_service',
+                $authenticationService
+            )
+        ;
+    }
+
+    protected function authenticatedAs($identity)
+    {
+        $authenticationService = $this->getMockBuilder(Authentication\AuthenticationService::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $authenticationService
+            ->expects($this->any())
+            ->method('hasIdentity')
+            ->willReturn(true)
+        ;
+
+        $authenticationService
+            ->expects($this->any())
+            ->method('getIdentity')
+            ->willReturn($identity)
+        ;
 
         $serviceManager = $this->getApplicationServiceLocator();
 

--- a/module/User/test/UserTest/Integration/Controller/UserControllerTest.php
+++ b/module/User/test/UserTest/Integration/Controller/UserControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace UserTest\Integration\Controller;
 
+use ApplicationTest\Integration\Util\AuthenticationTrait;
 use ApplicationTest\Integration\Util\Bootstrap;
 use User\Entity\User;
 use User\View\Helper\UserOrganizations;
@@ -17,6 +18,8 @@ use ZfModule\View\Helper\TotalModules;
  */
 class UserControllerTest extends AbstractHttpControllerTestCase
 {
+    use AuthenticationTrait;
+
     protected function setUp()
     {
         parent::setUp();
@@ -26,23 +29,7 @@ class UserControllerTest extends AbstractHttpControllerTestCase
 
     public function testIndexActionRedirectsIfNotAuthenticated()
     {
-        $authenticationService = $this->getMockBuilder(AuthenticationService::class)->getMock();
-
-        $authenticationService
-            ->expects($this->once())
-            ->method('hasIdentity')
-            ->willReturn(false)
-        ;
-
-        $serviceManager = $this->getApplicationServiceLocator();
-
-        $serviceManager
-            ->setAllowOverride(true)
-            ->setService(
-                'zfcuser_auth_service',
-                $authenticationService
-            )
-        ;
+        $this->notAuthenticated();
 
         $this->dispatch('/user');
 

--- a/module/User/test/UserTest/Integration/Controller/UserControllerTest.php
+++ b/module/User/test/UserTest/Integration/Controller/UserControllerTest.php
@@ -6,7 +6,6 @@ use ApplicationTest\Integration\Util\AuthenticationTrait;
 use ApplicationTest\Integration\Util\Bootstrap;
 use User\Entity\User;
 use User\View\Helper\UserOrganizations;
-use Zend\Authentication\AuthenticationService;
 use Zend\Http;
 use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
 use Zend\View;
@@ -42,23 +41,6 @@ class UserControllerTest extends AbstractHttpControllerTestCase
 
     public function testIndexActionSetsModulesIfAuthenticated()
     {
-        $authenticationService = $this->getMockBuilder(AuthenticationService::class)
-            ->disableOriginalConstructor()
-            ->getMock()
-        ;
-
-        $authenticationService
-            ->expects($this->any())
-            ->method('hasIdentity')
-            ->willReturn(true)
-        ;
-
-        $authenticationService
-            ->expects($this->any())
-            ->method('getIdentity')
-            ->willReturn(new User())
-        ;
-
         $moduleService = $this->getMockBuilder(Service\Module::class)
             ->disableOriginalConstructor()
             ->getMock()
@@ -74,10 +56,6 @@ class UserControllerTest extends AbstractHttpControllerTestCase
 
         $serviceManager
             ->setAllowOverride(true)
-            ->setService(
-                'zfcuser_auth_service',
-                $authenticationService
-            )
             ->setService(
                 'zfmodule_service_module',
                 $moduleService
@@ -120,6 +98,8 @@ class UserControllerTest extends AbstractHttpControllerTestCase
                 $totalModules
             )
         ;
+
+        $this->authenticatedAs(new User());
 
         $this->dispatch('/user');
 

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -165,39 +165,39 @@ class IndexController extends AbstractActionController
         }
 
         $request = $this->getRequest();
-        if ($request->isPost()) {
-            $repo = $request->getPost()->get('repo');
-            $owner  = $request->getPost()->get('owner');
+        if (!$request->isPost()) {
+            throw new Exception\UnexpectedValueException(
+                'Something went wrong with the post values of the request...'
+            );
+        }
 
-            $repository = $this->repositoryRetriever->getUserRepositoryMetadata($owner, $repo);
+        $repo = $request->getPost()->get('repo');
+        $owner  = $request->getPost()->get('owner');
 
-            if (!($repository instanceof \stdClass)) {
-                throw new Exception\RuntimeException(
-                    'Not able to fetch the repository from github due to an unknown error.',
-                    Http\Response::STATUS_CODE_500
-                );
-            }
+        $repository = $this->repositoryRetriever->getUserRepositoryMetadata($owner, $repo);
 
-            if (!$repository->fork && $repository->permissions->push) {
-                if ($this->moduleService->isModule($repository)) {
-                    $module = $this->moduleService->register($repository);
-                    $this->flashMessenger()->addMessage($module->getName() . ' has been added to ZF Modules');
-                } else {
-                    throw new Exception\UnexpectedValueException(
-                        $repository->name . ' is not a Zend Framework Module',
-                        Http\Response::STATUS_CODE_403
-                    );
-                }
+        if (!($repository instanceof \stdClass)) {
+            throw new Exception\RuntimeException(
+                'Not able to fetch the repository from github due to an unknown error.',
+                Http\Response::STATUS_CODE_500
+            );
+        }
+
+        if (!$repository->fork && $repository->permissions->push) {
+            if ($this->moduleService->isModule($repository)) {
+                $module = $this->moduleService->register($repository);
+                $this->flashMessenger()->addMessage($module->getName() . ' has been added to ZF Modules');
             } else {
                 throw new Exception\UnexpectedValueException(
-                    'You have no permission to add this module. The reason might be that you are' .
-                    'neither the owner nor a collaborator of this repository.',
+                    $repository->name . ' is not a Zend Framework Module',
                     Http\Response::STATUS_CODE_403
                 );
             }
         } else {
             throw new Exception\UnexpectedValueException(
-                'Something went wrong with the post values of the request...'
+                'You have no permission to add this module. The reason might be that you are' .
+                'neither the owner nor a collaborator of this repository.',
+                Http\Response::STATUS_CODE_403
             );
         }
 

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -242,15 +242,15 @@ class IndexController extends AbstractActionController
         }
 
         $module = $this->moduleMapper->findByUrl($repository->html_url);
-        if ($module instanceof \ZfModule\Entity\Module) {
-            $this->moduleMapper->delete($module);
-            $this->flashMessenger()->addMessage($repository->name . ' has been removed from ZF Modules');
-        } else {
+        if (!($module instanceof \ZfModule\Entity\Module)) {
             throw new Exception\UnexpectedValueException(
                 $repository->name . ' was not found',
                 Http\Response::STATUS_CODE_403
             );
         }
+
+        $this->moduleMapper->delete($module);
+        $this->flashMessenger()->addMessage($repository->name . ' has been removed from ZF Modules');
 
         return $this->redirect()->toRoute('zfcuser');
     }

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -246,7 +246,7 @@ class IndexController extends AbstractActionController
             }
         } else {
             throw new Exception\UnexpectedValueException(
-                'You have no permission to add this module. The reason might be that you are' .
+                'You have no permission to remove this module. The reason might be that you are ' .
                 'neither the owner nor a collaborator of this repository.',
                 Http\Response::STATUS_CODE_403
             );

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -124,21 +124,34 @@ class IndexController extends AbstractActionController
     }
 
     /**
-     * @param RepositoryCollection $repos
+     * @param RepositoryCollection $repositories
      * @return array
      */
-    private function fetchModules(RepositoryCollection $repos)
+    private function fetchModules(RepositoryCollection $repositories)
     {
-        $repositories = [];
+        $modules = [];
 
-        foreach ($repos as $repo) {
-            $isModule = $this->moduleService->isModule($repo);
-            if (!$repo->fork && $repo->permissions->push && $isModule && !$this->moduleMapper->findByName($repo->name)) {
-                $repositories[] = $repo;
+        foreach ($repositories as $repository) {
+            if ($repository->fork) {
+                continue;
             }
+
+            if (!$repository->permissions->push) {
+                continue;
+            }
+
+            if (!$this->moduleService->isModule($repository)) {
+                continue;
+            }
+
+            if ($this->moduleMapper->findByName($repository->name)) {
+                continue;
+            }
+
+            $modules[] = $repository;
         }
 
-        return $repositories;
+        return $modules;
     }
 
     /**

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -165,8 +165,10 @@ class IndexController extends AbstractActionController
             throw new Exception\UnexpectedValueException('Something went wrong with the post values of the request...');
         }
 
-        $repo = $request->getPost()->get('repo');
-        $owner  = $request->getPost()->get('owner');
+        $postParams = $request->getPost();
+
+        $repo = $postParams->get('repo');
+        $owner  = $postParams->get('owner');
 
         $repository = $this->repositoryRetriever->getUserRepositoryMetadata($owner, $repo);
 
@@ -213,8 +215,10 @@ class IndexController extends AbstractActionController
             throw new Exception\UnexpectedValueException('Something went wrong with the post values of the request...');
         }
 
-        $repo = $request->getPost()->get('repo');
-        $owner  = $request->getPost()->get('owner');
+        $postParams = $request->getPost();
+
+        $repo = $postParams->get('repo');
+        $owner  = $postParams->get('owner');
 
         $repository = $this->repositoryRetriever->getUserRepositoryMetadata($owner, $repo);
 

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -91,10 +91,11 @@ class IndexController extends AbstractActionController
             'direction' => 'desc',
         ];
 
-        $repos = $this->repositoryRetriever->getAuthenticatedUserRepositories($params);
-        $repositories = $this->filterModules($repos);
+        $repositories = $this->repositoryRetriever->getAuthenticatedUserRepositories($params);
 
-        $viewModel = new ViewModel(['repositories' => $repositories]);
+        $modules = $this->filterModules($repositories);
+
+        $viewModel = new ViewModel(['repositories' => $modules]);
         $viewModel->setTerminal(true);
 
         return $viewModel;
@@ -113,10 +114,11 @@ class IndexController extends AbstractActionController
             'direction' => 'desc',
         ];
 
-        $repos = $this->repositoryRetriever->getUserRepositories($owner, $params);
-        $repositories = $this->filterModules($repos);
+        $repositories = $this->repositoryRetriever->getUserRepositories($owner, $params);
 
-        $viewModel = new ViewModel(['repositories' => $repositories]);
+        $modules = $this->filterModules($repositories);
+
+        $viewModel = new ViewModel(['repositories' => $modules]);
         $viewModel->setTerminal(true);
         $viewModel->setTemplate('zf-module/index/index.phtml');
 

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -7,9 +7,14 @@ use EdpGithub\Collection\RepositoryCollection;
 use Zend\Http;
 use Zend\Mvc\Controller\AbstractActionController;
 use Zend\View\Model\ViewModel;
+use ZfcUser\Controller\Plugin;
 use ZfModule\Mapper;
 use ZfModule\Service;
 
+/**
+ * @method Http\Request getRequest()
+ * @method Plugin\ZfcUserAuthentication zfcUserAuthentication()
+ */
 class IndexController extends AbstractActionController
 {
     /**

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -166,9 +166,7 @@ class IndexController extends AbstractActionController
 
         $request = $this->getRequest();
         if (!$request->isPost()) {
-            throw new Exception\UnexpectedValueException(
-                'Something went wrong with the post values of the request...'
-            );
+            throw new Exception\UnexpectedValueException('Something went wrong with the post values of the request...');
         }
 
         $repo = $request->getPost()->get('repo');
@@ -216,9 +214,7 @@ class IndexController extends AbstractActionController
 
         $request = $this->getRequest();
         if (!$request->isPost()) {
-            throw new Exception\UnexpectedValueException(
-                'Something went wrong with the post values of the request...'
-            );
+            throw new Exception\UnexpectedValueException('Something went wrong with the post values of the request...');
         }
 
         $repo = $request->getPost()->get('repo');

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -233,21 +233,21 @@ class IndexController extends AbstractActionController
             );
         }
 
-        if (!$repository->fork && $repository->permissions->push) {
-            $module = $this->moduleMapper->findByUrl($repository->html_url);
-            if ($module instanceof \ZfModule\Entity\Module) {
-                $this->moduleMapper->delete($module);
-                $this->flashMessenger()->addMessage($repository->name . ' has been removed from ZF Modules');
-            } else {
-                throw new Exception\UnexpectedValueException(
-                    $repository->name . ' was not found',
-                    Http\Response::STATUS_CODE_403
-                );
-            }
-        } else {
+        if ($repository->fork || !$repository->permissions->push) {
             throw new Exception\UnexpectedValueException(
                 'You have no permission to remove this module. The reason might be that you are ' .
                 'neither the owner nor a collaborator of this repository.',
+                Http\Response::STATUS_CODE_403
+            );
+        }
+
+        $module = $this->moduleMapper->findByUrl($repository->html_url);
+        if ($module instanceof \ZfModule\Entity\Module) {
+            $this->moduleMapper->delete($module);
+            $this->flashMessenger()->addMessage($repository->name . ' has been removed from ZF Modules');
+        } else {
+            throw new Exception\UnexpectedValueException(
+                $repository->name . ' was not found',
                 Http\Response::STATUS_CODE_403
             );
         }

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -155,6 +155,7 @@ class IndexController extends AbstractActionController
 
     /**
      * @throws Exception\UnexpectedValueException
+     * @throws Exception\RuntimeException
      * @return Http\Response
      */
     public function addAction()
@@ -204,10 +205,9 @@ class IndexController extends AbstractActionController
     }
 
     /**
-     * This function is used to remove a module from the site
      * @throws Exception\UnexpectedValueException
-     * @return
-     **/
+     * @return Http\Response
+     */
     public function removeAction()
     {
         if (!$this->zfcUserAuthentication()->hasIdentity()) {

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -106,13 +106,12 @@ class IndexController extends AbstractActionController
         }
 
         $owner = $this->params()->fromRoute('owner', null);
-        $params = [
-            'per_page'  => 100,
-            'sort'      => 'updated',
-            'direction' => 'desc',
-        ];
 
-        $repositories = $this->repositoryRetriever->getUserRepositories($owner, $params);
+        $repositories = $this->repositoryRetriever->getUserRepositories($owner, [
+            'per_page' => 100,
+            'sort' => 'updated',
+            'direction' => 'desc',
+        ]);
 
         $modules = $this->filterModules($repositories);
 

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -84,14 +84,12 @@ class IndexController extends AbstractActionController
             return $this->redirect()->toRoute('zfcuser/login');
         }
 
-        $params = [
-            'type'      => 'all',
-            'per_page'  => 100,
-            'sort'      => 'updated',
+        $repositories = $this->repositoryRetriever->getAuthenticatedUserRepositories([
+            'type' => 'all',
+            'per_page' => 100,
+            'sort' => 'updated',
             'direction' => 'desc',
-        ];
-
-        $repositories = $this->repositoryRetriever->getAuthenticatedUserRepositories($params);
+        ]);
 
         $modules = $this->filterModules($repositories);
 

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -154,10 +154,9 @@ class IndexController extends AbstractActionController
     }
 
     /**
-     * This function is used to submit a module from the site
      * @throws Exception\UnexpectedValueException
-     * @return
-     **/
+     * @return Http\Response
+     */
     public function addAction()
     {
         if (!$this->zfcUserAuthentication()->hasIdentity()) {

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -176,7 +176,7 @@ class IndexController extends AbstractActionController
 
         if (!($repository instanceof \stdClass)) {
             throw new Exception\RuntimeException(
-                'Not able to fetch the repository from github due to an unknown error.',
+                'Not able to fetch the repository from GitHub due to an unknown error.',
                 Http\Response::STATUS_CODE_500
             );
         }
@@ -224,7 +224,7 @@ class IndexController extends AbstractActionController
 
         if (!$repository instanceof \stdClass) {
             throw new Exception\RuntimeException(
-                'Not able to fetch the repository from github due to an unknown error.',
+                'Not able to fetch the repository from GitHub due to an unknown error.',
                 Http\Response::STATUS_CODE_500
             );
         }

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -182,20 +182,20 @@ class IndexController extends AbstractActionController
             );
         }
 
-        if (!$repository->fork && $repository->permissions->push) {
-            if ($this->moduleService->isModule($repository)) {
-                $module = $this->moduleService->register($repository);
-                $this->flashMessenger()->addMessage($module->getName() . ' has been added to ZF Modules');
-            } else {
-                throw new Exception\UnexpectedValueException(
-                    $repository->name . ' is not a Zend Framework Module',
-                    Http\Response::STATUS_CODE_403
-                );
-            }
-        } else {
+        if ($repository->fork || !$repository->permissions->push) {
             throw new Exception\UnexpectedValueException(
                 'You have no permission to add this module. The reason might be that you are ' .
                 'neither the owner nor a collaborator of this repository.',
+                Http\Response::STATUS_CODE_403
+            );
+        }
+
+        if ($this->moduleService->isModule($repository)) {
+            $module = $this->moduleService->register($repository);
+            $this->flashMessenger()->addMessage($module->getName() . ' has been added to ZF Modules');
+        } else {
+            throw new Exception\UnexpectedValueException(
+                $repository->name . ' is not a Zend Framework Module',
                 Http\Response::STATUS_CODE_403
             );
         }

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -92,7 +92,7 @@ class IndexController extends AbstractActionController
         ];
 
         $repos = $this->repositoryRetriever->getAuthenticatedUserRepositories($params);
-        $repositories = $this->fetchModules($repos);
+        $repositories = $this->filterModules($repos);
 
         $viewModel = new ViewModel(['repositories' => $repositories]);
         $viewModel->setTerminal(true);
@@ -114,7 +114,7 @@ class IndexController extends AbstractActionController
         ];
 
         $repos = $this->repositoryRetriever->getUserRepositories($owner, $params);
-        $repositories = $this->fetchModules($repos);
+        $repositories = $this->filterModules($repos);
 
         $viewModel = new ViewModel(['repositories' => $repositories]);
         $viewModel->setTerminal(true);
@@ -127,7 +127,7 @@ class IndexController extends AbstractActionController
      * @param RepositoryCollection $repositories
      * @return array
      */
-    private function fetchModules(RepositoryCollection $repositories)
+    private function filterModules(RepositoryCollection $repositories)
     {
         $modules = [];
 

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -68,7 +68,7 @@ class IndexController extends AbstractActionController
         /* HOTFIX for https://github.com/EvanDotPro/EdpGithub/issues/23 - markdown needs to be the last request */
         $readme = $this->repositoryRetriever->getRepositoryFileContent($vendor, $module, 'README.md', true);
 
-        $viewModel = new ViewModel([
+        return new ViewModel([
             'vendor' => $vendor,
             'module' => $module,
             'repository' => $repository,
@@ -76,8 +76,6 @@ class IndexController extends AbstractActionController
             'composerConf' => $composerConf,
             'license' => $license,
         ]);
-
-        return $viewModel;
     }
 
     public function indexAction()

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -128,29 +128,25 @@ class IndexController extends AbstractActionController
      */
     private function filterModules(RepositoryCollection $repositories)
     {
-        $modules = [];
-
-        foreach ($repositories as $repository) {
+        return array_filter(iterator_to_array($repositories), function ($repository) {
             if ($repository->fork) {
-                continue;
+                return false;
             }
 
             if (!$repository->permissions->push) {
-                continue;
+                return false;
             }
 
             if (!$this->moduleService->isModule($repository)) {
-                continue;
+                return false;
             }
 
             if ($this->moduleMapper->findByName($repository->name)) {
-                continue;
+                return false;
             }
 
-            $modules[] = $repository;
-        }
-
-        return $modules;
+            return true;
+        });
     }
 
     /**

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -194,7 +194,7 @@ class IndexController extends AbstractActionController
             }
         } else {
             throw new Exception\UnexpectedValueException(
-                'You have no permission to add this module. The reason might be that you are' .
+                'You have no permission to add this module. The reason might be that you are ' .
                 'neither the owner nor a collaborator of this repository.',
                 Http\Response::STATUS_CODE_403
             );

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -190,15 +190,15 @@ class IndexController extends AbstractActionController
             );
         }
 
-        if ($this->moduleService->isModule($repository)) {
-            $module = $this->moduleService->register($repository);
-            $this->flashMessenger()->addMessage($module->getName() . ' has been added to ZF Modules');
-        } else {
+        if (!$this->moduleService->isModule($repository)) {
             throw new Exception\UnexpectedValueException(
                 $repository->name . ' is not a Zend Framework Module',
                 Http\Response::STATUS_CODE_403
             );
         }
+
+        $module = $this->moduleService->register($repository);
+        $this->flashMessenger()->addMessage($module->getName() . ' has been added to ZF Modules');
 
         return $this->redirect()->toRoute('zfcuser');
     }

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -242,7 +242,8 @@ class IndexController extends AbstractActionController
         }
 
         $module = $this->moduleMapper->findByUrl($repository->html_url);
-        if (!($module instanceof \ZfModule\Entity\Module)) {
+
+        if (!$module) {
             throw new Exception\UnexpectedValueException(
                 $repository->name . ' was not found',
                 Http\Response::STATUS_CODE_403

--- a/module/ZfModule/src/ZfModule/Mapper/Module.php
+++ b/module/ZfModule/src/ZfModule/Mapper/Module.php
@@ -8,6 +8,7 @@ use Zend\Paginator\Adapter\DbSelect;
 use Zend\Paginator\Paginator;
 use Zend\Stdlib\Hydrator\HydratorInterface;
 use ZfcBase\Mapper\AbstractDbMapper;
+use ZfModule\Entity;
 
 class Module extends AbstractDbMapper implements ModuleInterface
 {
@@ -110,6 +111,10 @@ class Module extends AbstractDbMapper implements ModuleInterface
         return $this->findBy('name', $name);
     }
 
+    /**
+     * @param string $url
+     * @return Entity\Module
+     */
     public function findByUrl($url)
     {
         return $this->findBy('url', $url);

--- a/module/ZfModule/src/ZfModule/Service/Module.php
+++ b/module/ZfModule/src/ZfModule/Service/Module.php
@@ -41,7 +41,7 @@ class Module extends EventProvider
         $module = $this->moduleMapper->findByUrl($url);
         $update = true;
         if (!$module) {
-            $module  = new \ZfModule\Entity\Module();
+            $module  = new Entity\Module();
             $update = false;
         }
 

--- a/module/ZfModule/src/ZfModule/Service/Module.php
+++ b/module/ZfModule/src/ZfModule/Service/Module.php
@@ -32,7 +32,7 @@ class Module extends EventProvider
     }
 
     /**
-     * @param array $data
+     * @param stdClass $data
      * @return object|Entity\Module
      */
     public function register($data)

--- a/module/ZfModule/src/ZfModule/Service/Module.php
+++ b/module/ZfModule/src/ZfModule/Service/Module.php
@@ -32,11 +32,8 @@ class Module extends EventProvider
     }
 
     /**
-     * createFromForm
-     *
      * @param array $data
-     * @return \ZfcUser\Entity\UserInterface
-     * @throws Exception\InvalidArgumentException
+     * @return object|Entity\Module
      */
     public function register($data)
     {

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -5,6 +5,8 @@ namespace ZfModuleTest\Integration\Controller;
 use Application\Service;
 use ApplicationTest\Integration\Util\Bootstrap;
 use stdClass;
+use Zend\Authentication\AuthenticationService;
+use Zend\Http;
 use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
 use ZfModule\Controller;
 use ZfModule\Mapper;
@@ -18,16 +20,55 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $this->setApplicationConfig(Bootstrap::getConfig());
     }
 
-    public function testIndexActionCanBeAccessed()
+    public function testIndexActionRedirectsIfNotAuthenticated()
     {
+        $authenticationService = $this->getMockBuilder(AuthenticationService::class)->getMock();
+
+        $authenticationService
+            ->expects($this->once())
+            ->method('hasIdentity')
+            ->willReturn(false)
+        ;
+
+        $serviceManager = $this->getApplicationServiceLocator();
+
+        $serviceManager
+            ->setAllowOverride(true)
+            ->setService(
+                'zfcuser_auth_service',
+                $authenticationService
+            )
+        ;
+
         $this->dispatch('/module');
 
         $this->assertControllerName(Controller\IndexController::class);
         $this->assertActionName('index');
+        $this->assertResponseStatusCode(Http\Response::STATUS_CODE_302);
+
+        $this->assertRedirectTo('/user/login');
     }
 
-    public function testOrganizationActionCanBeAccessed()
+    public function testOrganizationActionRedirectsIfNotAuthenticated()
     {
+        $authenticationService = $this->getMockBuilder(AuthenticationService::class)->getMock();
+
+        $authenticationService
+            ->expects($this->once())
+            ->method('hasIdentity')
+            ->willReturn(false)
+        ;
+
+        $serviceManager = $this->getApplicationServiceLocator();
+
+        $serviceManager
+            ->setAllowOverride(true)
+            ->setService(
+                'zfcuser_auth_service',
+                $authenticationService
+            )
+        ;
+
         $owner = 'foo';
 
         $url = sprintf(
@@ -39,6 +80,9 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         $this->assertControllerName(Controller\IndexController::class);
         $this->assertActionName('organization');
+        $this->assertResponseStatusCode(Http\Response::STATUS_CODE_302);
+
+        $this->assertRedirectTo('/user/login');
     }
 
     public function testViewActionCanBeAccessed()

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -90,17 +90,15 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         $validModule = $this->validModule();
 
-        $forkedModule = $this->forkedModule();
         $nonModule = $this->nonModule();
         $registeredModule = $this->registeredModule();
-        $moduleWithoutPushPermissions = $this->moduleWithoutPushPermissions();
 
         $repositories = [
             $validModule,
             $nonModule,
-            $forkedModule,
-            $moduleWithoutPushPermissions,
             $registeredModule,
+            $this->forkedModule(),
+            $this->moduleWithoutPushPermissions(),
         ];
 
         $repositoryCollection = $this->repositoryCollectionMock($repositories);
@@ -298,17 +296,15 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         $validModule = $this->validModule();
 
-        $forkedModule = $this->forkedModule();
         $nonModule = $this->nonModule();
         $registeredModule = $this->registeredModule();
-        $moduleWithoutPushPermissions = $this->moduleWithoutPushPermissions();
 
         $repositories = [
             $validModule,
             $nonModule,
-            $forkedModule,
-            $moduleWithoutPushPermissions,
             $registeredModule,
+            $this->forkedModule(),
+            $this->moduleWithoutPushPermissions(),
         ];
 
         $repositoryCollection = $this->repositoryCollectionMock($repositories);

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -849,6 +849,34 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $this->assertRedirectTo('/user/login');
     }
 
+    /**
+     * @dataProvider providerNotPost
+     *
+     * @param string $method
+     */
+    public function testRemoveActionThrowsUnexpectedValueExceptionIfNotPostedTo($method)
+    {
+        $this->authenticatedAs(new User());
+
+        $this->dispatch(
+            '/module/remove',
+            $method
+        );
+
+        $this->assertControllerName(Controller\IndexController::class);
+        $this->assertActionName('remove');
+        $this->assertResponseStatusCode(Http\Response::STATUS_CODE_500);
+
+        /* @var View\Model\ViewModel  $result */
+        $result = $this->getApplication()->getMvcEvent()->getResult();
+
+        /* @var Exception $exception */
+        $exception = $result->getVariable('exception');
+
+        $this->assertInstanceOf(Controller\Exception\UnexpectedValueException::class, $exception);
+        $this->assertSame('Something went wrong with the post values of the request...', $exception->getMessage());
+    }
+
     public function testViewActionSetsHttp404ResponseCodeIfModuleNotFound()
     {
         $vendor = 'foo';

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -590,7 +590,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         $this->assertInstanceOf(Controller\Exception\RuntimeException::class, $exception);
         $this->assertSame(
-            'Not able to fetch the repository from github due to an unknown error.',
+            'Not able to fetch the repository from GitHub due to an unknown error.',
             $exception->getMessage()
         );
     }
@@ -928,7 +928,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         $this->assertInstanceOf(Controller\Exception\RuntimeException::class, $exception);
         $this->assertSame(
-            'Not able to fetch the repository from github due to an unknown error.',
+            'Not able to fetch the repository from GitHub due to an unknown error.',
             $exception->getMessage()
         );
     }

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -84,18 +84,19 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
     }
 
-    public function testIndexActionFiltersOutUserRepositoriesWhichAreNeitherModulesNorAddedNorEligibleOtherwise()
+    public function testIndexActionRendersValidModulesOnly()
     {
         $this->authenticatedAs(new User());
 
-        $module = $this->validModule();
+        $validModule = $this->validModule();
+
         $forkedModule = $this->forkedModule();
         $nonModule = $this->nonModule();
         $registeredModule = $this->registeredModule();
         $moduleWithoutPushPermissions = $this->moduleWithoutPushPermissions();
 
         $repositories = [
-            $module,
+            $validModule,
             $nonModule,
             $forkedModule,
             $moduleWithoutPushPermissions,
@@ -187,7 +188,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         $this->assertInternalType('array', $viewVariable);
         $this->assertCount(1, $viewVariable);
-        $this->assertSame($module, $viewVariable[0]);
+        $this->assertSame($validModule, $viewVariable[0]);
     }
 
     public function testOrganizationActionRedirectsIfNotAuthenticated()
@@ -297,18 +298,19 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
     }
 
-    public function testOrganizationActionFiltersOutUserRepositoriesWhichAreNeitherModulesNorAddedNorEligibleOtherwise()
+    public function testOrganizationActionRendersValidModulesOnly()
     {
         $this->authenticatedAs(new User());
 
-        $module = $this->validModule();
+        $validModule = $this->validModule();
+
         $forkedModule = $this->forkedModule();
         $nonModule = $this->nonModule();
         $registeredModule = $this->registeredModule();
         $moduleWithoutPushPermissions = $this->moduleWithoutPushPermissions();
 
         $repositories = [
-            $module,
+            $validModule,
             $nonModule,
             $forkedModule,
             $moduleWithoutPushPermissions,
@@ -409,7 +411,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         $this->assertInternalType('array', $viewVariable);
         $this->assertCount(1, $viewVariable);
-        $this->assertSame($module, $viewVariable[0]);
+        $this->assertSame($validModule, $viewVariable[0]);
     }
 
     public function testAddActionRedirectsIfNotAuthenticated()

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -22,23 +22,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
     public function testIndexActionRedirectsIfNotAuthenticated()
     {
-        $authenticationService = $this->getMockBuilder(AuthenticationService::class)->getMock();
-
-        $authenticationService
-            ->expects($this->once())
-            ->method('hasIdentity')
-            ->willReturn(false)
-        ;
-
-        $serviceManager = $this->getApplicationServiceLocator();
-
-        $serviceManager
-            ->setAllowOverride(true)
-            ->setService(
-                'zfcuser_auth_service',
-                $authenticationService
-            )
-        ;
+        $this->notAuthenticated();
 
         $this->dispatch('/module');
 
@@ -51,23 +35,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
     public function testOrganizationActionRedirectsIfNotAuthenticated()
     {
-        $authenticationService = $this->getMockBuilder(AuthenticationService::class)->getMock();
-
-        $authenticationService
-            ->expects($this->once())
-            ->method('hasIdentity')
-            ->willReturn(false)
-        ;
-
-        $serviceManager = $this->getApplicationServiceLocator();
-
-        $serviceManager
-            ->setAllowOverride(true)
-            ->setService(
-                'zfcuser_auth_service',
-                $authenticationService
-            )
-        ;
+        $this->notAuthenticated();
 
         $owner = 'foo';
 
@@ -87,23 +55,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
     public function testAddActionRedirectsIfNotAuthenticated()
     {
-        $authenticationService = $this->getMockBuilder(AuthenticationService::class)->getMock();
-
-        $authenticationService
-            ->expects($this->once())
-            ->method('hasIdentity')
-            ->willReturn(false)
-        ;
-
-        $serviceManager = $this->getApplicationServiceLocator();
-
-        $serviceManager
-            ->setAllowOverride(true)
-            ->setService(
-                'zfcuser_auth_service',
-                $authenticationService
-            )
-        ;
+        $this->notAuthenticated();
 
         $this->dispatch('/module/add');
 
@@ -116,23 +68,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
     public function testRemoveActionRedirectsIfNotAuthenticated()
     {
-        $authenticationService = $this->getMockBuilder(AuthenticationService::class)->getMock();
-
-        $authenticationService
-            ->expects($this->once())
-            ->method('hasIdentity')
-            ->willReturn(false)
-        ;
-
-        $serviceManager = $this->getApplicationServiceLocator();
-
-        $serviceManager
-            ->setAllowOverride(true)
-            ->setService(
-                'zfcuser_auth_service',
-                $authenticationService
-            )
-        ;
+        $this->notAuthenticated();
 
         $this->dispatch('/module/remove');
 
@@ -197,5 +133,26 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         $this->assertControllerName(Controller\IndexController::class);
         $this->assertActionName('view');
+    }
+
+    private function notAuthenticated()
+    {
+        $authenticationService = $this->getMockBuilder(AuthenticationService::class)
+            ->getMock();
+
+        $authenticationService
+            ->expects($this->once())
+            ->method('hasIdentity')
+            ->willReturn(false);
+
+        $serviceManager = $this->getApplicationServiceLocator();
+
+        $serviceManager
+            ->setAllowOverride(true)
+            ->setService(
+                'zfcuser_auth_service',
+                $authenticationService
+            )
+        ;
     }
 }

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -81,6 +81,44 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $this->assertRedirectTo('/user/login');
     }
 
+    public function testViewActionSetsHttp404ResponseCodeIfModuleNotFound()
+    {
+        $vendor = 'foo';
+        $module = 'bar';
+
+        $moduleMapper = $this->getMockBuilder(Mapper\Module::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $moduleMapper
+            ->expects($this->once())
+            ->method('findByName')
+            ->with($this->equalTo($module))
+            ->willReturn(null)
+        ;
+
+        $this->getApplicationServiceLocator()
+            ->setAllowOverride(true)
+            ->setService(
+                'zfmodule_mapper_module',
+                $moduleMapper
+            )
+        ;
+
+        $url = sprintf(
+            '/%s/%s',
+            $vendor,
+            $module
+        );
+
+        $this->dispatch($url);
+
+        $this->assertControllerName(Controller\IndexController::class);
+        $this->assertActionName('not-found');
+        $this->assertResponseStatusCode(Http\Response::STATUS_CODE_404);
+    }
+
     public function testViewActionCanBeAccessed()
     {
         $vendor = 'foo';

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -114,6 +114,35 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $this->assertRedirectTo('/user/login');
     }
 
+    public function testRemoveActionRedirectsIfNotAuthenticated()
+    {
+        $authenticationService = $this->getMockBuilder(AuthenticationService::class)->getMock();
+
+        $authenticationService
+            ->expects($this->once())
+            ->method('hasIdentity')
+            ->willReturn(false)
+        ;
+
+        $serviceManager = $this->getApplicationServiceLocator();
+
+        $serviceManager
+            ->setAllowOverride(true)
+            ->setService(
+                'zfcuser_auth_service',
+                $authenticationService
+            )
+        ;
+
+        $this->dispatch('/module/remove');
+
+        $this->assertControllerName(Controller\IndexController::class);
+        $this->assertActionName('remove');
+        $this->assertResponseStatusCode(Http\Response::STATUS_CODE_302);
+
+        $this->assertRedirectTo('/user/login');
+    }
+
     public function testViewActionCanBeAccessed()
     {
         $vendor = 'foo';

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -238,6 +238,46 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $this->assertRedirectTo('/user/login');
     }
 
+    public function testOrganizationActionFetches100MostRecentlyUpdatedRepositoriesWhenNoOwnerIsSpecified()
+    {
+        $this->authenticatedAs(new User());
+
+        $repositoryCollection = $this->repositoryCollectionMock();
+
+        $repositoryRetriever = $this->getMockBuilder(RepositoryRetriever::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $repositoryRetriever
+            ->expects($this->once())
+            ->method('getUserRepositories')
+            ->with(
+                $this->equalTo(null),
+                $this->equalTo([
+                    'per_page' => 100,
+                    'sort' => 'updated',
+                    'direction' => 'desc',
+                ]
+            ))
+            ->willReturn($repositoryCollection)
+        ;
+
+        $this->getApplicationServiceLocator()
+            ->setAllowOverride(true)
+            ->setService(
+                RepositoryRetriever::class,
+                $repositoryRetriever
+            )
+        ;
+
+        $this->dispatch('/module/list');
+
+        $this->assertControllerName(Controller\IndexController::class);
+        $this->assertActionName('organization');
+        $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
+    }
+
     public function testAddActionRedirectsIfNotAuthenticated()
     {
         $this->notAuthenticated();

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -85,6 +85,35 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $this->assertRedirectTo('/user/login');
     }
 
+    public function testAddActionRedirectsIfNotAuthenticated()
+    {
+        $authenticationService = $this->getMockBuilder(AuthenticationService::class)->getMock();
+
+        $authenticationService
+            ->expects($this->once())
+            ->method('hasIdentity')
+            ->willReturn(false)
+        ;
+
+        $serviceManager = $this->getApplicationServiceLocator();
+
+        $serviceManager
+            ->setAllowOverride(true)
+            ->setService(
+                'zfcuser_auth_service',
+                $authenticationService
+            )
+        ;
+
+        $this->dispatch('/module/add');
+
+        $this->assertControllerName(Controller\IndexController::class);
+        $this->assertActionName('add');
+        $this->assertResponseStatusCode(Http\Response::STATUS_CODE_302);
+
+        $this->assertRedirectTo('/user/login');
+    }
+
     public function testViewActionCanBeAccessed()
     {
         $vendor = 'foo';

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -88,53 +88,19 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
     {
         $this->authenticatedAs(new User());
 
-        $repositories = [];
+        $module = $this->validModule();
+        $forkedModule = $this->forkedModule();
+        $nonModule = $this->nonModule();
+        $registeredModule = $this->registeredModule();
+        $moduleWithoutPushPermissions = $this->moduleWithoutPushPermissions();
 
-        $module = new stdClass();
-        $module->name = 'foo';
-        $module->description = 'blah blah';
-        $module->fork = false;
-        $module->created_at = '1970-01-01 00:00:00';
-        $module->html_url = 'http://www.example.org';
-        $module->owner = new stdClass();
-        $module->owner->login = 'johndoe';
-        $module->owner->avatar_url = 'johndoe';
-        $module->permissions = new stdClass();
-        $module->permissions->push = true;
-
-        array_push($repositories, $module);
-
-        $nonModule = new stdClass();
-        $nonModule->name = 'bar';
-        $nonModule->fork = false;
-        $nonModule->permissions = new stdClass();
-        $nonModule->permissions->push = true;
-
-        array_push($repositories, $nonModule);
-
-        $forkedModule = new stdClass();
-        $forkedModule->name = 'baz';
-        $forkedModule->fork = true;
-        $forkedModule->permissions = new stdClass();
-        $forkedModule->permissions->push = true;
-
-        array_push($repositories, $forkedModule);
-
-        $moduleWithoutPushPermissions = new stdClass();
-        $moduleWithoutPushPermissions->name = 'qux';
-        $moduleWithoutPushPermissions->fork = false;
-        $moduleWithoutPushPermissions->permissions = new stdClass();
-        $moduleWithoutPushPermissions->permissions->push = false;
-
-        array_push($repositories, $moduleWithoutPushPermissions);
-
-        $registeredModule = new stdClass();
-        $registeredModule->name = 'vqz';
-        $registeredModule->fork = false;
-        $registeredModule->permissions = new stdClass();
-        $registeredModule->permissions->push = true;
-
-        array_push($repositories, $registeredModule);
+        $repositories = [
+            $module,
+            $nonModule,
+            $forkedModule,
+            $moduleWithoutPushPermissions,
+            $registeredModule,
+        ];
 
         $repositoryCollection = $this->repositoryCollectionMock($repositories);
 
@@ -335,53 +301,19 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
     {
         $this->authenticatedAs(new User());
 
-        $repositories = [];
+        $module = $this->validModule();
+        $forkedModule = $this->forkedModule();
+        $nonModule = $this->nonModule();
+        $registeredModule = $this->registeredModule();
+        $moduleWithoutPushPermissions = $this->moduleWithoutPushPermissions();
 
-        $module = new stdClass();
-        $module->name = 'foo';
-        $module->description = 'blah blah';
-        $module->fork = false;
-        $module->created_at = '1970-01-01 00:00:00';
-        $module->html_url = 'http://www.example.org';
-        $module->owner = new stdClass();
-        $module->owner->login = 'johndoe';
-        $module->owner->avatar_url = 'johndoe';
-        $module->permissions = new stdClass();
-        $module->permissions->push = true;
-
-        array_push($repositories, $module);
-
-        $nonModule = new stdClass();
-        $nonModule->name = 'bar';
-        $nonModule->fork = false;
-        $nonModule->permissions = new stdClass();
-        $nonModule->permissions->push = true;
-
-        array_push($repositories, $nonModule);
-
-        $forkedModule = new stdClass();
-        $forkedModule->name = 'baz';
-        $forkedModule->fork = true;
-        $forkedModule->permissions = new stdClass();
-        $forkedModule->permissions->push = true;
-
-        array_push($repositories, $forkedModule);
-
-        $moduleWithoutPushPermissions = new stdClass();
-        $moduleWithoutPushPermissions->name = 'qux';
-        $moduleWithoutPushPermissions->fork = false;
-        $moduleWithoutPushPermissions->permissions = new stdClass();
-        $moduleWithoutPushPermissions->permissions->push = false;
-
-        array_push($repositories, $moduleWithoutPushPermissions);
-
-        $registeredModule = new stdClass();
-        $registeredModule->name = 'vqz';
-        $registeredModule->fork = false;
-        $registeredModule->permissions = new stdClass();
-        $registeredModule->permissions->push = true;
-
-        array_push($repositories, $registeredModule);
+        $repositories = [
+            $module,
+            $nonModule,
+            $forkedModule,
+            $moduleWithoutPushPermissions,
+            $registeredModule,
+        ];
 
         $repositoryCollection = $this->repositoryCollectionMock($repositories);
 
@@ -662,21 +594,12 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
      */
     public function providerRepositoryWithInsufficientPrivileges()
     {
-        $repository = new stdClass();
-        $repository->permissions = new stdClass();
-
-        $repository->fork = true;
-        $repository->permissions->push = true;
-
         yield [
-            $repository,
+            $this->forkedModule(),
         ];
 
-        $repository->fork = false;
-        $repository->permissions->push = false;
-
         yield [
-            $repository,
+            $this->moduleWithoutPushPermissions(),
         ];
     }
 
@@ -692,11 +615,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
             ->getMock()
         ;
 
-        $repository = new stdClass();
-        $repository->name = 'foo';
-        $repository->fork = false;
-        $repository->permissions = new stdClass();
-        $repository->permissions->push = true;
+        $nonModule = $this->nonModule();
 
         $repositoryRetriever
             ->expects($this->once())
@@ -705,7 +624,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
                 $this->equalTo($vendor),
                 $this->equalTo($name)
             )
-            ->willReturn($repository)
+            ->willReturn($nonModule)
         ;
 
         $moduleService = $this->getMockBuilder(Service\Module::class)
@@ -716,7 +635,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $moduleService
             ->expects($this->once())
             ->method('isModule')
-            ->with($this->equalTo($repository))
+            ->with($this->equalTo($nonModule))
             ->willReturn(false)
         ;
 
@@ -755,7 +674,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $this->assertSame(
             sprintf(
                 '%s is not a Zend Framework Module',
-                $repository->name
+                $nonModule->name
             ),
             $exception->getMessage()
         );
@@ -773,11 +692,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
             ->getMock()
         ;
 
-        $repository = new stdClass();
-        $repository->name = 'foo';
-        $repository->fork = false;
-        $repository->permissions = new stdClass();
-        $repository->permissions->push = true;
+        $validModule = $this->validModule();
 
         $repositoryRetriever
             ->expects($this->once())
@@ -786,7 +701,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
                 $this->equalTo($vendor),
                 $this->equalTo($name)
             )
-            ->willReturn($repository)
+            ->willReturn($validModule)
         ;
 
         $moduleService = $this->getMockBuilder(Service\Module::class)
@@ -797,14 +712,14 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $moduleService
             ->expects($this->once())
             ->method('isModule')
-            ->with($this->equalTo($repository))
+            ->with($this->equalTo($validModule))
             ->willReturn(true)
         ;
 
         $moduleService
             ->expects($this->once())
             ->method('register')
-            ->with($this->equalTo($repository))
+            ->with($this->equalTo($validModule))
             ->willReturn(new Entity\Module())
         ;
 
@@ -1007,12 +922,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
             ->getMock()
         ;
 
-        $repository = new stdClass();
-        $repository->name = 'foo';
-        $repository->html_url = 'http://example.org';
-        $repository->fork = false;
-        $repository->permissions = new stdClass();
-        $repository->permissions->push = true;
+        $unregisteredModule = $this->unregisteredModule();
 
         $repositoryRetriever
             ->expects($this->once())
@@ -1021,7 +931,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
                 $this->equalTo($vendor),
                 $this->equalTo($name)
             )
-            ->willReturn($repository)
+            ->willReturn($unregisteredModule)
         ;
 
         $moduleMapper = $this->getMockBuilder(Mapper\Module::class)
@@ -1032,7 +942,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $moduleMapper
             ->expects($this->once())
             ->method('findByUrl')
-            ->with($this->equalTo($repository->html_url))
+            ->with($this->equalTo($unregisteredModule->html_url))
             ->willReturn(false)
         ;
 
@@ -1071,7 +981,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $this->assertSame(
             sprintf(
                 '%s was not found',
-                $repository->name
+                $unregisteredModule->name
             ),
             $exception->getMessage()
         );
@@ -1089,12 +999,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
             ->getMock()
         ;
 
-        $repository = new stdClass();
-        $repository->name = 'foo';
-        $repository->html_url = 'http://example.org';
-        $repository->fork = false;
-        $repository->permissions = new stdClass();
-        $repository->permissions->push = true;
+        $registeredModule = $this->registeredModule();
 
         $repositoryRetriever
             ->expects($this->once())
@@ -1103,7 +1008,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
                 $this->equalTo($vendor),
                 $this->equalTo($name)
             )
-            ->willReturn($repository)
+            ->willReturn($registeredModule)
         ;
 
         $moduleMapper = $this->getMockBuilder(Mapper\Module::class)
@@ -1116,7 +1021,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $moduleMapper
             ->expects($this->once())
             ->method('findByUrl')
-            ->with($this->equalTo($repository->html_url))
+            ->with($this->equalTo($registeredModule->html_url))
             ->willReturn($module)
         ;
 
@@ -1371,5 +1276,90 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         ;
 
         return $repositoryCollection;
+    }
+
+    /**
+     * @return stdClass
+     */
+    private function validModule()
+    {
+        $repository = new stdClass();
+
+        $repository->name = 'foo';
+        $repository->description = 'blah blah';
+        $repository->fork = false;
+        $repository->created_at = '1970-01-01 00:00:00';
+        $repository->html_url = 'http://www.example.org';
+
+        $repository->owner = new stdClass();
+        $repository->owner->login = 'johndoe';
+        $repository->owner->avatar_url = 'johndoe';
+
+        $repository->permissions = new stdClass();
+        $repository->permissions->push = true;
+
+        return $repository;
+    }
+
+    /**
+     * @return stdClass
+     */
+    private function nonModule()
+    {
+        $repository = $this->validModule();
+
+        $repository->name = 'non-module';
+
+        return $repository;
+    }
+
+    /**
+     * @return stdClass
+     */
+    private function forkedModule()
+    {
+        $repository = $this->validModule();
+
+        $repository->name = 'forked-module';
+        $repository->fork = true;
+
+        return $repository;
+    }
+
+    /**
+     * @return stdClass
+     */
+    private function moduleWithoutPushPermissions()
+    {
+        $repository = $this->validModule();
+
+        $repository->name = 'module-without-push-permissions';
+        $repository->permissions->push = false;
+
+        return $repository;
+    }
+
+    /**
+     * @return stdClass
+     */
+    private function registeredModule()
+    {
+        $repository = $this->validModule();
+
+        $repository->name = 'registered-module';
+
+        return $repository;
+    }
+
+    /**
+     * @return stdClass
+     */
+    private function unregisteredModule()
+    {
+        $repository = $this->validModule();
+
+        $repository->name = 'unregistered-module';
+
+        return $repository;
     }
 }

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -113,12 +113,6 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $repositoryRetriever
             ->expects($this->once())
             ->method('getAuthenticatedUserRepositories')
-            ->with($this->equalTo([
-                'type' => 'all',
-                'per_page' => 100,
-                'sort' => 'updated',
-                'direction' => 'desc',
-            ]))
             ->willReturn($repositoryCollection)
         ;
 
@@ -329,14 +323,6 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $repositoryRetriever
             ->expects($this->once())
             ->method('getUserRepositories')
-            ->with(
-                $this->equalTo($vendor),
-                $this->equalTo([
-                    'per_page' => 100,
-                    'sort' => 'updated',
-                    'direction' => 'desc',
-                ])
-            )
             ->willReturn($repositoryCollection)
         ;
 

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -650,7 +650,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         $this->assertInstanceOf(Controller\Exception\UnexpectedValueException::class, $exception);
         $this->assertSame(
-            'You have no permission to add this module. The reason might be that you are' .
+            'You have no permission to add this module. The reason might be that you are ' .
             'neither the owner nor a collaborator of this repository.',
             $exception->getMessage()
         );

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -254,7 +254,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
             ->getMock()
         ;
 
-        $vendor = 'johndoe';
+        $vendor = 'suzie';
 
         $repositoryRetriever
             ->expects($this->once())
@@ -314,7 +314,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
             ->getMock()
         ;
 
-        $vendor = 'johndoe';
+        $vendor = 'suzie';
 
         $repositoryRetriever
             ->expects($this->once())
@@ -459,7 +459,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
     {
         $this->authenticatedAs(new User());
 
-        $vendor = 'johndoe';
+        $vendor = 'suzie';
         $name = 'foo';
 
         $repositoryRetriever = $this->getMockBuilder(RepositoryRetriever::class)
@@ -520,7 +520,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
     {
         $this->authenticatedAs(new User());
 
-        $vendor = 'johndoe';
+        $vendor = 'suzie';
         $name = 'foo';
 
         $repositoryRetriever = $this->getMockBuilder(RepositoryRetriever::class)
@@ -591,7 +591,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
     {
         $this->authenticatedAs(new User());
 
-        $vendor = 'johndoe';
+        $vendor = 'suzie';
         $name = 'foo';
 
         $repositoryRetriever = $this->getMockBuilder(RepositoryRetriever::class)
@@ -668,7 +668,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
     {
         $this->authenticatedAs(new User());
 
-        $vendor = 'johndoe';
+        $vendor = 'suzie';
         $name = 'foo';
 
         $repositoryRetriever = $this->getMockBuilder(RepositoryRetriever::class)
@@ -780,7 +780,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
     {
         $this->authenticatedAs(new User());
 
-        $vendor = 'johndoe';
+        $vendor = 'suzie';
         $name = 'foo';
 
         $repositoryRetriever = $this->getMockBuilder(RepositoryRetriever::class)
@@ -841,7 +841,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
     {
         $this->authenticatedAs(new User());
 
-        $vendor = 'johndoe';
+        $vendor = 'suzie';
         $name = 'foo';
 
         $repositoryRetriever = $this->getMockBuilder(RepositoryRetriever::class)
@@ -898,7 +898,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
     {
         $this->authenticatedAs(new User());
 
-        $vendor = 'johndoe';
+        $vendor = 'suzie';
         $name = 'foo';
 
         $repositoryRetriever = $this->getMockBuilder(RepositoryRetriever::class)
@@ -975,7 +975,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
     {
         $this->authenticatedAs(new User());
 
-        $vendor = 'johndoe';
+        $vendor = 'suzie';
         $name = 'foo';
 
         $repositoryRetriever = $this->getMockBuilder(RepositoryRetriever::class)
@@ -1276,8 +1276,8 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $repository->html_url = 'http://www.example.org';
 
         $repository->owner = new stdClass();
-        $repository->owner->login = 'johndoe';
-        $repository->owner->avatar_url = 'johndoe';
+        $repository->owner->login = 'suzie';
+        $repository->owner->avatar_url = 'http://www.example.org/img/suzie.gif';
 
         $repository->permissions = new stdClass();
         $repository->permissions->push = true;

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -989,7 +989,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         $this->assertInstanceOf(Controller\Exception\UnexpectedValueException::class, $exception);
         $this->assertSame(
-            'You have no permission to add this module. The reason might be that you are' .
+            'You have no permission to remove this module. The reason might be that you are ' .
             'neither the owner nor a collaborator of this repository.',
             $exception->getMessage()
         );

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -3,9 +3,9 @@
 namespace ZfModuleTest\Integration\Controller;
 
 use Application\Service;
+use ApplicationTest\Integration\Util\AuthenticationTrait;
 use ApplicationTest\Integration\Util\Bootstrap;
 use stdClass;
-use Zend\Authentication\AuthenticationService;
 use Zend\Http;
 use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
 use ZfModule\Controller;
@@ -13,6 +13,8 @@ use ZfModule\Mapper;
 
 class IndexControllerTest extends AbstractHttpControllerTestCase
 {
+    use AuthenticationTrait;
+
     protected function setUp()
     {
         parent::setUp();
@@ -133,26 +135,5 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         $this->assertControllerName(Controller\IndexController::class);
         $this->assertActionName('view');
-    }
-
-    private function notAuthenticated()
-    {
-        $authenticationService = $this->getMockBuilder(AuthenticationService::class)
-            ->getMock();
-
-        $authenticationService
-            ->expects($this->once())
-            ->method('hasIdentity')
-            ->willReturn(false);
-
-        $serviceManager = $this->getApplicationServiceLocator();
-
-        $serviceManager
-            ->setAllowOverride(true)
-            ->setService(
-                'zfcuser_auth_service',
-                $authenticationService
-            )
-        ;
     }
 }

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -278,6 +278,53 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
     }
 
+    public function testOrganizationActionFetches100MostRecentlyUpdatedRepositoriesWithOwnerSpecified()
+    {
+        $this->authenticatedAs(new User());
+
+        $repositoryCollection = $this->repositoryCollectionMock();
+
+        $repositoryRetriever = $this->getMockBuilder(RepositoryRetriever::class)
+            ->disableOriginalConstructor()
+            ->getMock()
+        ;
+
+        $owner = 'johndoe';
+
+        $repositoryRetriever
+            ->expects($this->once())
+            ->method('getUserRepositories')
+            ->with(
+                $this->equalTo($owner),
+                $this->equalTo([
+                    'per_page' => 100,
+                    'sort' => 'updated',
+                    'direction' => 'desc',
+                ]
+            ))
+            ->willReturn($repositoryCollection)
+        ;
+
+        $this->getApplicationServiceLocator()
+            ->setAllowOverride(true)
+            ->setService(
+                RepositoryRetriever::class,
+                $repositoryRetriever
+            )
+        ;
+
+        $url = sprintf(
+            '/module/list/%s',
+            $owner
+        );
+
+        $this->dispatch($url);
+
+        $this->assertControllerName(Controller\IndexController::class);
+        $this->assertActionName('organization');
+        $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
+    }
+
     public function testAddActionRedirectsIfNotAuthenticated()
     {
         $this->notAuthenticated();

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -516,7 +516,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
      *
      * @param stdClass $repository
      */
-    public function testAddActionThrowsUnexpectedValueExceptionWhenRepositoryIsForkOrUserHasNoPushPermissions($repository)
+    public function testAddActionThrowsUnexpectedValueExceptionWhenRepositoryHasInsufficientPrivileges($repository)
     {
         $this->authenticatedAs(new User());
 
@@ -837,7 +837,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
      *
      * @param stdClass $repository
      */
-    public function testRemoveActionThrowsUnexpectedValueExceptionWhenRepositoryIsForkOrUserHasNoPushPermissions($repository)
+    public function testRemoveActionThrowsUnexpectedValueExceptionWhenRepositoryHasInsufficientPrivileges($repository)
     {
         $this->authenticatedAs(new User());
 

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -211,6 +211,9 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         /* @var Mvc\Application $application */
         $viewModel = $this->getApplication()->getMvcEvent()->getViewModel();
 
+        $this->assertTrue($viewModel->terminate());
+        $this->assertSame('zf-module/index/index', $viewModel->getTemplate());
+
         $viewVariable = $viewModel->getVariable('repositories');
 
         $this->assertInternalType('array', $viewVariable);
@@ -463,6 +466,9 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         /* @var Mvc\Application $application */
         $viewModel = $this->getApplication()->getMvcEvent()->getViewModel();
+
+        $this->assertTrue($viewModel->terminate());
+        $this->assertSame('zf-module/index/index.phtml', $viewModel->getTemplate());
 
         $viewVariable = $viewModel->getVariable('repositories');
 


### PR DESCRIPTION
This PR

* [x] adds tests for `ZfModule\Controller\IndexController`
* [x] extracts `ApplicationTest\Integration\Util\AuthenticationTrait` for mocking authentication in integration tests, provides `authenticatedAs($identity)` and `notAuthenticated()`
* [x] cleans up `ZfModule\Controller\IndexController`