### PR TITLE
Fix: Use alternative syntax in view scripts

### DIFF
--- a/module/User/view/scn-social-auth/user/login.phtml
+++ b/module/User/view/scn-social-auth/user/login.phtml
@@ -3,13 +3,11 @@
     <p>
         There is no sign-up form anymore! Just log in with your GitHub account. All your information will be provided by GitHub.
     </p>
-    <?php
-    $socialSignIn = true;
-    foreach ($this->options->getEnabledProviders() as $provider) {
-        if ($socialSignIn) {
-            $socialSignIn = false;
-        }
-        echo '<p>' . $this->socialSignInButton($provider) . '</p>';
-    }
-    ?>
+    <?php $socialSignIn = true; ?>
+    <?php foreach ($this->options->getEnabledProviders() as $provider): ?>
+        <?php if ($socialSignIn): ?>
+            <?php $socialSignIn = false; ?>
+        <?php endif; ?>
+        <p><?php echo $this->socialSignInButton($provider); ?></p>
+    <?php endforeach; ?>
 </div>

--- a/module/User/view/scn-social-auth/user/login.phtml
+++ b/module/User/view/scn-social-auth/user/login.phtml
@@ -3,11 +3,7 @@
     <p>
         There is no sign-up form anymore! Just log in with your GitHub account. All your information will be provided by GitHub.
     </p>
-    <?php $socialSignIn = true; ?>
     <?php foreach ($this->options->getEnabledProviders() as $provider): ?>
-        <?php if ($socialSignIn): ?>
-            <?php $socialSignIn = false; ?>
-        <?php endif; ?>
         <p><?php echo $this->socialSignInButton($provider); ?></p>
     <?php endforeach; ?>
 </div>

--- a/module/User/view/zfc-user/user/index.phtml
+++ b/module/User/view/zfc-user/user/index.phtml
@@ -11,7 +11,7 @@
             </div>
         </div>
         <?php foreach ($this->flashMessenger()->getMessages() as $message): ?>
-            <h3 class="zf-green"><?php echo $message ?></h3>
+            <h3 class="zf-green"><?php echo $message; ?></h3>
         <?php endforeach; ?>
 
         <ul class="nav nav-tabs">
@@ -42,17 +42,17 @@
                 ?>
             </div>
             <div class="tab-pane" id="repositories">
-                <div class="well" style="text-align:center">Synchronizing with GitHub <img src="<?php echo $this->basePath('/img/ajax-loader.gif') ?>" alt="loading" /></div>
+                <div class="well" style="text-align:center">Synchronizing with GitHub <img src="<?php echo $this->basePath('/img/ajax-loader.gif'); ?>" alt="loading" /></div>
             </div>
 
             <div class="tab-pane" id="organizations">
-                <?php echo $this->userOrganizations() ?>
+                <?php echo $this->userOrganizations(); ?>
             </div>
         </div>
     </div>
     <div class="col-md-4">
         <div class="sidebar" style="text-align: center">
-            <h3 style="text-align:center">Hello, <?php echo $this->zfcUserDisplayName() ?>!</h3>
+            <h3 style="text-align:center">Hello, <?php echo $this->zfcUserDisplayName(); ?>!</h3>
             <?php /* @var User\Entity\User $identity */ ?>
             <?php $identity = $this->zfcUserIdentity(); ?>
             <img class="thumbnail" src="<?php echo $identity->getPhotoUrl(); ?>" alt="<?php echo $this->zfcUserDisplayName() ?>"/>

--- a/module/User/view/zfc-user/user/index.phtml
+++ b/module/User/view/zfc-user/user/index.phtml
@@ -22,20 +22,21 @@
         <br />
         <div class="tab-content">
             <div class="tab-pane active" id="modules">
-                <?php if (empty($modules)): ?>
+            <?php if (0 === count($modules)): ?>
                 <div class="alert alert-block">No modules have been submitted yet</div>
-                <?php endif; ?>
+            <?php else: ?>
                 <?php foreach ($modules as $module): ?>
-                <?php echo $this->moduleView([
-                        'owner' => $module->getOwner(),
-                        'name' => $module->getName(),
-                        'created_at' => $module->getCreatedAt(),
-                        'url' => $module->getUrl(),
-                        'photo_url' => $module->getPhotoUrl(),
-                        'description' => $module->getDescription(),
-                    ], 'remove');
-                ?>
+                    <?php echo $this->moduleView([
+                            'owner' => $module->getOwner(),
+                            'name' => $module->getName(),
+                            'created_at' => $module->getCreatedAt(),
+                            'url' => $module->getUrl(),
+                            'photo_url' => $module->getPhotoUrl(),
+                            'description' => $module->getDescription(),
+                        ], 'remove');
+                    ?>
                 <?php endforeach; ?>
+            <?php endif; ?>
             </div>
             <div class="tab-pane" id="repositories">
                 <div class="well" style="text-align:center">Synchronizing with GitHub <img src="<?php echo $this->basePath('/img/ajax-loader.gif'); ?>" alt="loading" /></div>

--- a/module/User/view/zfc-user/user/index.phtml
+++ b/module/User/view/zfc-user/user/index.phtml
@@ -57,12 +57,4 @@
         </div>
     </div>
 </div>
-
-<?php
-$url = $this->url('zf-module');
-$this->inlineScript()->appendScript(<<<EOT
-
-$("#repositories").load("$url");
-
-EOT
-);
+<?php $this->inlineScript()->appendScript('$("#repositories").load("' . $this->url('zf-module') . '");'); ?>

--- a/module/User/view/zfc-user/user/index.phtml
+++ b/module/User/view/zfc-user/user/index.phtml
@@ -22,15 +22,11 @@
         <br />
         <div class="tab-content">
             <div class="tab-pane active" id="modules">
-                <?php
-                if (empty($modules)) {
-                    ?>
-                    <div class="alert alert-block">No modules have been submitted yet</div>
-                    <?php
-                }
-                /* @var ZfModule\Entity\Module[] $modules */
-                foreach ($modules as $module) {
-                    echo $this->moduleView([
+                <?php if (empty($modules)): ?>
+                <div class="alert alert-block">No modules have been submitted yet</div>
+                <?php endif; ?>
+                <?php foreach ($modules as $module): ?>
+                <?php echo $this->moduleView([
                         'owner' => $module->getOwner(),
                         'name' => $module->getName(),
                         'created_at' => $module->getCreatedAt(),
@@ -38,8 +34,8 @@
                         'photo_url' => $module->getPhotoUrl(),
                         'description' => $module->getDescription(),
                     ], 'remove');
-                }
                 ?>
+                <?php endforeach; ?>
             </div>
             <div class="tab-pane" id="repositories">
                 <div class="well" style="text-align:center">Synchronizing with GitHub <img src="<?php echo $this->basePath('/img/ajax-loader.gif'); ?>" alt="loading" /></div>

--- a/module/User/view/zfc-user/user/index.phtml
+++ b/module/User/view/zfc-user/user/index.phtml
@@ -11,7 +11,7 @@
             </div>
         </div>
         <?php foreach ($this->flashMessenger()->getMessages() as $message): ?>
-            <h3 class="zf-green"><?php echo $message; ?></h3>
+            <h3 class="zf-green"><?php echo $this->escapeHtml($message); ?></h3>
         <?php endforeach; ?>
 
         <ul class="nav nav-tabs">

--- a/module/User/view/zfc-user/user/index.phtml
+++ b/module/User/view/zfc-user/user/index.phtml
@@ -57,4 +57,4 @@
         </div>
     </div>
 </div>
-<?php $this->inlineScript()->appendScript('$("#repositories").load("' . $this->url('zf-module') . '");'); ?>
+<?php $this->inlineScript()->appendScript('$("#repositories").load("' . $this->escapeJs($this->url('zf-module')) . '");'); ?>


### PR DESCRIPTION
This PR

* [x] adds a few semicolons (for consistency)
* [x] uses alternative syntax in view scripts (also for consistency)
* [x] removes an assignment and a condition with effect, but no use
* [x] while at it, escapes a few unescaped strings in the view templates affected above