### PR TITLE
Fix: github vs GitHub

### DIFF
--- a/module/User/view/scn-social-auth/user/login.phtml
+++ b/module/User/view/scn-social-auth/user/login.phtml
@@ -1,7 +1,7 @@
 <h1 style="text-align:center">Sign in</h1>
 <div class="well" style="text-align:center">
     <p>
-        There is no sign-up form anymore! Just log in with your github account. All your information will be provided by Github.
+        There is no sign-up form anymore! Just log in with your GitHub account. All your information will be provided by Github.
     </p>
     <?php
     $socialSignIn = true;

--- a/module/User/view/scn-social-auth/user/login.phtml
+++ b/module/User/view/scn-social-auth/user/login.phtml
@@ -1,7 +1,7 @@
 <h1 style="text-align:center">Sign in</h1>
 <div class="well" style="text-align:center">
     <p>
-        There is no sign-up form anymore! Just log in with your GitHub account. All your information will be provided by Github.
+        There is no sign-up form anymore! Just log in with your GitHub account. All your information will be provided by GitHub.
     </p>
     <?php
     $socialSignIn = true;

--- a/module/User/view/user/helper/user-organizations.phtml
+++ b/module/User/view/user/helper/user-organizations.phtml
@@ -19,7 +19,7 @@
         <div class="row accordion-body collapse" id="org-<?php echo $this->escapeHtmlAttr($org->login) ?>">
             <div class="module-description">
                 <div class="col-md-12" id="org-content-<?php echo $this->escapeHtmlAttr($org->login) ?>">
-                    <div class="well" style="text-align:center">Synchronizing with Github <img src="<?php echo $this->basePath('/img/ajax-loader.gif') ?>" alt="loading" /></div>
+                    <div class="well" style="text-align:center">Synchronizing with GitHub <img src="<?php echo $this->basePath('/img/ajax-loader.gif') ?>" alt="loading" /></div>
                 </div>
             </div>
         </div>

--- a/module/User/view/zfc-user/user/index.phtml
+++ b/module/User/view/zfc-user/user/index.phtml
@@ -41,7 +41,7 @@
                 ?>
             </div>
             <div class="tab-pane" id="repositories">
-                <div class="well" style="text-align:center">Synchronizing with Github <img src="<?php echo $this->basePath('/img/ajax-loader.gif') ?>" alt="loading" /></div>
+                <div class="well" style="text-align:center">Synchronizing with GitHub <img src="<?php echo $this->basePath('/img/ajax-loader.gif') ?>" alt="loading" /></div>
             </div>
 
             <div class="tab-pane" id="organizations">


### PR DESCRIPTION
This PR

* [x] fixes small typos (`github` or `Github` vs. `GitHub`)