### PR TITLE
Fix: Remove useless User\Mapper\UserHydrator

### DIFF
--- a/module/User/src/User/Mapper/UserFactory.php
+++ b/module/User/src/User/Mapper/UserFactory.php
@@ -5,6 +5,7 @@ namespace User\Mapper;
 use Zend\Db;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use ZfcUser\Mapper;
 use ZfcUser\Options;
 
 class UserFactory implements FactoryInterface
@@ -27,7 +28,7 @@ class UserFactory implements FactoryInterface
 
         $mapper->setDbAdapter($dbAdapter);
         $mapper->setEntityPrototype(new $entityClass());
-        $mapper->setHydrator(new UserHydrator());
+        $mapper->setHydrator(new Mapper\UserHydrator());
 
         return $mapper;
     }

--- a/module/User/src/User/Mapper/UserHydrator.php
+++ b/module/User/src/User/Mapper/UserHydrator.php
@@ -1,9 +1,0 @@
-<?php
-
-namespace User\Mapper;
-
-use ZfcUser\Mapper\UserHydrator as  ZfcUserMapperHydrator;
-
-class UserHydrator extends ZfcUserMapperHydrator
-{
-}


### PR DESCRIPTION
This PR

* [x] removes the - what I believe to be useless (unless I'm missing something) - `User\Mapper\UserHydrator`