### PR TITLE
Enhancement: Simplify usage of ModuleView view helper

### DIFF
--- a/module/User/src/User/Controller/UserController.php
+++ b/module/User/src/User/Controller/UserController.php
@@ -33,7 +33,7 @@ class UserController extends ZfcUserController
         }
 
         $viewModel = new ViewModel([
-            'modules' => $this->moduleService->currentUserModules(),
+            'repositories' => $this->moduleService->currentUserModules(),
         ]);
 
         $viewModel->setTemplate('zfc-user/user/index');

--- a/module/User/view/zfc-user/user/index.phtml
+++ b/module/User/view/zfc-user/user/index.phtml
@@ -23,7 +23,7 @@
         <div class="tab-content">
             <div class="tab-pane active" id="modules">
             <?php /* @var ZfModule\Entity\Module[] $modules */ ?>
-            <?php if (0 === count($modules)): ?>
+            <?php if (!count($modules)): ?>
                 <div class="alert alert-block">No modules have been submitted yet</div>
             <?php else: ?>
                 <?php foreach ($modules as $module): ?>

--- a/module/User/view/zfc-user/user/index.phtml
+++ b/module/User/view/zfc-user/user/index.phtml
@@ -27,7 +27,7 @@
                 <div class="alert alert-block">No modules have been submitted yet</div>
             <?php else: ?>
                 <?php foreach ($modules as $module): ?>
-                    <?php echo $this->moduleView($module, ZfModule\View\Helper\ModuleView::BUTTON_REMOVE); ?>
+                    <?php echo $this->repository($module, ZfModule\View\Helper\Repository::BUTTON_REMOVE); ?>
                 <?php endforeach; ?>
             <?php endif; ?>
             </div>

--- a/module/User/view/zfc-user/user/index.phtml
+++ b/module/User/view/zfc-user/user/index.phtml
@@ -22,6 +22,7 @@
         <br />
         <div class="tab-content">
             <div class="tab-pane active" id="modules">
+            <?php /* @var ZfModule\Entity\Module[] $modules */ ?>
             <?php if (0 === count($modules)): ?>
                 <div class="alert alert-block">No modules have been submitted yet</div>
             <?php else: ?>

--- a/module/User/view/zfc-user/user/index.phtml
+++ b/module/User/view/zfc-user/user/index.phtml
@@ -22,7 +22,7 @@
         <br />
         <div class="tab-content">
             <div class="tab-pane active" id="modules">
-            <?php /* @var ZfModule\Entity\Module[] $modules */ ?>
+            <?php /* @var stdClass[] $modules */ ?>
             <?php if (!count($modules)): ?>
                 <div class="alert alert-block">No modules have been submitted yet</div>
             <?php else: ?>

--- a/module/User/view/zfc-user/user/index.phtml
+++ b/module/User/view/zfc-user/user/index.phtml
@@ -27,7 +27,7 @@
                 <div class="alert alert-block">No modules have been submitted yet</div>
             <?php else: ?>
                 <?php foreach ($modules as $module): ?>
-                    <?php echo $this->moduleView($module, 'remove'); ?>
+                    <?php echo $this->moduleView($module, ZfModule\View\Helper\ModuleView::BUTTON_REMOVE); ?>
                 <?php endforeach; ?>
             <?php endif; ?>
             </div>

--- a/module/User/view/zfc-user/user/index.phtml
+++ b/module/User/view/zfc-user/user/index.phtml
@@ -22,12 +22,12 @@
         <br />
         <div class="tab-content">
             <div class="tab-pane active" id="modules">
-            <?php /* @var stdClass[] $modules */ ?>
-            <?php if (!count($modules)): ?>
+            <?php /* @var stdClass[] $repositories */ ?>
+            <?php if (!count($repositories)): ?>
                 <div class="alert alert-block">No modules have been submitted yet</div>
             <?php else: ?>
-                <?php foreach ($modules as $module): ?>
-                    <?php echo $this->repository($module, ZfModule\View\Helper\Repository::BUTTON_REMOVE); ?>
+                <?php foreach ($repositories as $repository): ?>
+                    <?php echo $this->repository($repository, ZfModule\View\Helper\Repository::BUTTON_REMOVE); ?>
                 <?php endforeach; ?>
             <?php endif; ?>
             </div>

--- a/module/User/view/zfc-user/user/index.phtml
+++ b/module/User/view/zfc-user/user/index.phtml
@@ -27,15 +27,7 @@
                 <div class="alert alert-block">No modules have been submitted yet</div>
             <?php else: ?>
                 <?php foreach ($modules as $module): ?>
-                    <?php echo $this->moduleView([
-                            'owner' => $module->getOwner(),
-                            'name' => $module->getName(),
-                            'created_at' => $module->getCreatedAt(),
-                            'url' => $module->getUrl(),
-                            'photo_url' => $module->getPhotoUrl(),
-                            'description' => $module->getDescription(),
-                        ], 'remove');
-                    ?>
+                    <?php echo $this->moduleView($module, 'remove'); ?>
                 <?php endforeach; ?>
             <?php endif; ?>
             </div>

--- a/module/ZfModule/config/module.config.php
+++ b/module/ZfModule/config/module.config.php
@@ -80,7 +80,7 @@ return [
             'totalModules' => Helper\TotalModulesFactory::class,
         ],
         'invokables' => [
-            'moduleView'        => Helper\ModuleView::class,
+            'repository'        => Helper\Repository::class,
             'moduleDescription' => Helper\ModuleDescription::class,
             'composerView'      => Helper\ComposerView::class,
         ],

--- a/module/ZfModule/src/ZfModule/Controller/IndexController.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexController.php
@@ -85,16 +85,16 @@ class IndexController extends AbstractActionController
             return $this->redirect()->toRoute('zfcuser/login');
         }
 
-        $repositories = $this->repositoryRetriever->getAuthenticatedUserRepositories([
+        $currentUserRepositories = $this->repositoryRetriever->getAuthenticatedUserRepositories([
             'type' => 'all',
             'per_page' => 100,
             'sort' => 'updated',
             'direction' => 'desc',
         ]);
 
-        $modules = $this->filterModules($repositories);
+        $repositories = $this->registeredRepositories($currentUserRepositories);
 
-        $viewModel = new ViewModel(['repositories' => $modules]);
+        $viewModel = new ViewModel(['repositories' => $repositories]);
         $viewModel->setTerminal(true);
 
         return $viewModel;
@@ -108,15 +108,15 @@ class IndexController extends AbstractActionController
 
         $owner = $this->params()->fromRoute('owner', null);
 
-        $repositories = $this->repositoryRetriever->getUserRepositories($owner, [
+        $userRepositories = $this->repositoryRetriever->getUserRepositories($owner, [
             'per_page' => 100,
             'sort' => 'updated',
             'direction' => 'desc',
         ]);
 
-        $modules = $this->filterModules($repositories);
+        $repositories = $this->registeredRepositories($userRepositories);
 
-        $viewModel = new ViewModel(['repositories' => $modules]);
+        $viewModel = new ViewModel(['repositories' => $repositories]);
         $viewModel->setTerminal(true);
         $viewModel->setTemplate('zf-module/index/index.phtml');
 
@@ -127,7 +127,7 @@ class IndexController extends AbstractActionController
      * @param RepositoryCollection $repositories
      * @return stdClass[]
      */
-    private function filterModules(RepositoryCollection $repositories)
+    private function registeredRepositories(RepositoryCollection $repositories)
     {
         return array_filter(iterator_to_array($repositories), function ($repository) {
             if ($repository->fork) {

--- a/module/ZfModule/src/ZfModule/Service/Module.php
+++ b/module/ZfModule/src/ZfModule/Service/Module.php
@@ -112,7 +112,7 @@ class Module extends EventProvider
     }
 
     /**
-     * @return Entity\Module[]
+     * @return stdClass[]
      */
     public function currentUserModules()
     {
@@ -122,25 +122,20 @@ class Module extends EventProvider
             'per_page' => 100,
         ]);
 
-        $modules = [];
-
-        foreach ($repositoryCollection as $repository) {
+        return array_filter(iterator_to_array($repositoryCollection), function ($repository) {
             if (true === $repository->fork) {
-                continue;
+                return false;
             }
 
             if (false === $repository->permissions->push) {
-                continue;
+                return false;
             }
 
-            $module = $this->moduleMapper->findByUrl($repository->html_url);
-            if (!($module instanceof Entity\Module)) {
-                continue;
+            if (null === $this->moduleMapper->findByUrl($repository->html_url)) {
+                return false;
             }
 
-            array_push($modules, $module);
-        }
-
-        return $modules;
+            return true;
+        });
     }
 }

--- a/module/ZfModule/src/ZfModule/View/Helper/ModuleView.php
+++ b/module/ZfModule/src/ZfModule/View/Helper/ModuleView.php
@@ -2,10 +2,8 @@
 
 namespace ZfModule\View\Helper;
 
-use InvalidArgumentException;
 use stdClass;
 use Zend\View\Helper\AbstractHelper;
-use ZfModule\Entity;
 
 class ModuleView extends AbstractHelper
 {
@@ -13,53 +11,20 @@ class ModuleView extends AbstractHelper
     const BUTTON_REMOVE = 'remove';
 
     /**
-     * @param Entity\Module|stdClass $module
+     * @param stdClass $module
      * @param string $button
      * @return string
      */
     public function __invoke($module, $button = 'submit')
     {
-        $values = $this->fetchValues($module);
-
-        $values += [
+        return $this->getView()->render('zf-module/helper/module-view.phtml', [
+            'owner' => $module->owner->login,
+            'name' => $module->name,
+            'createdAt' => $module->created_at,
+            'url' => $module->html_url,
+            'photoUrl' => $module->owner->avatar_url,
+            'description' => $module->description,
             'button' => $button,
-        ];
-
-        return $this->getView()->render('zf-module/helper/module-view.phtml', $values);
-    }
-
-    /**
-     * @param stdClass|Entity\Module$module
-     * @return array
-     */
-    private function fetchValues($module)
-    {
-        if ((!$module instanceof stdClass) && !($module instanceof Entity\Module)) {
-            throw new InvalidArgumentException(sprintf(
-                'Parameter "%s" needs to be specified as %s',
-                '$module',
-                'an instance of stdClass or ZfModule\Entity\Module'
-            ));
-        }
-
-        if ($module instanceof stdClass) {
-            return [
-                'owner' => $module->owner->login,
-                'name' => $module->name,
-                'createdAt' => $module->created_at,
-                'url' => $module->html_url,
-                'photoUrl' => $module->owner->avatar_url,
-                'description' => $module->description,
-            ];
-        }
-
-        return [
-            'owner' => $module->getOwner(),
-            'name' => $module->getName(),
-            'createdAt' => $module->getCreatedAt(),
-            'url' => $module->getUrl(),
-            'photoUrl' => $module->getPhotoUrl(),
-            'description' => $module->getDescription(),
-        ];
+        ]);
     }
 }

--- a/module/ZfModule/src/ZfModule/View/Helper/ModuleView.php
+++ b/module/ZfModule/src/ZfModule/View/Helper/ModuleView.php
@@ -9,6 +9,9 @@ use ZfModule\Entity;
 
 class ModuleView extends AbstractHelper
 {
+    const BUTTON_SUBMIT = 'submit';
+    const BUTTON_REMOVE = 'remove';
+
     /**
      * @param Entity\Module|stdClass $module
      * @param string $button

--- a/module/ZfModule/src/ZfModule/View/Helper/ModuleView.php
+++ b/module/ZfModule/src/ZfModule/View/Helper/ModuleView.php
@@ -2,20 +2,61 @@
 
 namespace ZfModule\View\Helper;
 
+use InvalidArgumentException;
+use stdClass;
 use Zend\View\Helper\AbstractHelper;
+use ZfModule\Entity;
 
 class ModuleView extends AbstractHelper
 {
     /**
-     * @param array $module
+     * @param Entity\Module|stdClass $module
      * @param string $button
      * @return string
      */
     public function __invoke($module, $button = 'submit')
     {
-        return $this->getView()->render('zf-module/helper/module-view.phtml', [
-            'module' => $module,
+        $values = $this->fetchValues($module);
+
+        $values += [
             'button' => $button,
-        ]);
+        ];
+
+        return $this->getView()->render('zf-module/helper/module-view.phtml', $values);
+    }
+
+    /**
+     * @param stdClass|Entity\Module$module
+     * @return array
+     */
+    private function fetchValues($module)
+    {
+        if ((!$module instanceof stdClass) && !($module instanceof Entity\Module)) {
+            throw new InvalidArgumentException(sprintf(
+                'Parameter "%s" needs to be specified as %s',
+                '$module',
+                'an instance of stdClass or ZfModule\Entity\Module'
+            ));
+        }
+
+        if ($module instanceof stdClass) {
+            return [
+                'owner' => $module->owner->login,
+                'name' => $module->name,
+                'createdAt' => $module->created_at,
+                'url' => $module->html_url,
+                'photoUrl' => $module->owner->avatar_url,
+                'description' => $module->description,
+            ];
+        }
+
+        return [
+            'owner' => $module->getOwner(),
+            'name' => $module->getName(),
+            'createdAt' => $module->getCreatedAt(),
+            'url' => $module->getUrl(),
+            'photoUrl' => $module->getPhotoUrl(),
+            'description' => $module->getDescription(),
+        ];
     }
 }

--- a/module/ZfModule/src/ZfModule/View/Helper/Repository.php
+++ b/module/ZfModule/src/ZfModule/View/Helper/Repository.php
@@ -5,7 +5,7 @@ namespace ZfModule\View\Helper;
 use stdClass;
 use Zend\View\Helper\AbstractHelper;
 
-class ModuleView extends AbstractHelper
+class Repository extends AbstractHelper
 {
     const BUTTON_SUBMIT = 'submit';
     const BUTTON_REMOVE = 'remove';
@@ -17,7 +17,7 @@ class ModuleView extends AbstractHelper
      */
     public function __invoke($module, $button = 'submit')
     {
-        return $this->getView()->render('zf-module/helper/module-view.phtml', [
+        return $this->getView()->render('zf-module/helper/repository.phtml', [
             'owner' => $module->owner->login,
             'name' => $module->name,
             'createdAt' => $module->created_at,

--- a/module/ZfModule/test/ZfModuleTest/Integration/View/Helper/RepositoryTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/View/Helper/RepositoryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace ZfModuleTest\Integration\View\Helper;
+
+use ApplicationTest\Integration\Util\Bootstrap;
+use PHPUnit_Framework_TestCase;
+use Zend\View\HelperPluginManager;
+use ZfModule\View\Helper;
+
+/**
+ * @coversNothing
+ */
+class RepositoryTest extends PHPUnit_Framework_TestCase
+{
+    public function testCanRetrieveService()
+    {
+        $serviceManager = Bootstrap::getServiceManager();
+
+        /* @var HelperPluginManager $helperPluginManager */
+        $helperPluginManager = $serviceManager->get('ViewHelperManager');
+
+        $this->assertInstanceOf(
+            Helper\Repository::class,
+            $helperPluginManager->get('repository')
+        );
+    }
+}

--- a/module/ZfModule/test/ZfModuleTest/Service/ModuleTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Service/ModuleTest.php
@@ -83,11 +83,11 @@ class ModuleTest extends PHPUnit_Framework_TestCase
     {
         $repository = $this->repository();
 
-        $module = $this->getMockBuilder(Entity\Module::class)->getMock();
-
-        $modules = [
-            $module,
+        $repositories = [
+            $repository,
         ];
+
+        $module = $this->getMockBuilder(Entity\Module::class)->getMock();
 
         $moduleMapper = $this->getMockBuilder(Mapper\Module::class)->getMock();
 
@@ -124,7 +124,7 @@ class ModuleTest extends PHPUnit_Framework_TestCase
             $githubClient
         );
 
-        $this->assertSame($modules, $service->currentUserModules());
+        $this->assertSame($repositories, $service->currentUserModules());
     }
 
     public function testListUserModulesDoesNotLookupModulesFromApiWhereUserHasNoPushPrivilege()
@@ -221,7 +221,7 @@ class ModuleTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('findByUrl')
             ->with($this->equalTo($repository->html_url))
-            ->willReturn(false)
+            ->willReturn(null)
         ;
 
         $currentUserService = $this->getMockBuilder(Api\CurrentUser::class)->getMock();

--- a/module/ZfModule/test/ZfModuleTest/View/Helper/ModuleViewTest.php
+++ b/module/ZfModule/test/ZfModuleTest/View/Helper/ModuleViewTest.php
@@ -5,7 +5,6 @@ namespace ZfModuleTest\View\Helper;
 use PHPUnit_Framework_TestCase;
 use stdClass;
 use Zend\View;
-use ZfModule\Entity;
 use ZfModule\View\Helper;
 
 class ModuleViewTest extends PHPUnit_Framework_TestCase
@@ -39,53 +38,9 @@ class ModuleViewTest extends PHPUnit_Framework_TestCase
         $helper($repository);
     }
 
-    public function testInvokeHandlesModule()
-    {
-        $module = $this->module();
-
-        $view = $this->getMockForAbstractClass(View\Renderer\RendererInterface::class);
-
-        $view
-            ->expects($this->once())
-            ->method('render')
-            ->with(
-                $this->equalTo('zf-module/helper/module-view.phtml'),
-                $this->equalTo([
-                    'owner' => $module->getOwner(),
-                    'name' => $module->getName(),
-                    'createdAt' => $module->getCreatedAt(),
-                    'url' => $module->getUrl(),
-                    'photoUrl' => $module->getPhotoUrl(),
-                    'description' => $module->getDescription(),
-                    'button' => 'submit',
-                ])
-            )
-        ;
-
-        $helper = new Helper\ModuleView();
-        $helper->setView($view);
-
-        $helper($module);
-    }
-
-    /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testInvokeDoesNotHandleAnythingElse()
-    {
-        $module = 'foo';
-
-        $view = $this->getMockForAbstractClass(View\Renderer\RendererInterface::class);
-
-        $helper = new Helper\ModuleView();
-        $helper->setView($view);
-
-        $helper($module);
-    }
-
     public function testInvokeAllowsSpecifyingButtonType()
     {
-        $module = $this->module();
+        $repository = $this->repository();
         $button = 'baz';
 
         $view = $this->getMockForAbstractClass(View\Renderer\RendererInterface::class);
@@ -107,7 +62,7 @@ class ModuleViewTest extends PHPUnit_Framework_TestCase
         $helper = new Helper\ModuleView();
         $helper->setView($view);
 
-        $helper($module, $button);
+        $helper($repository, $button);
     }
 
     /**
@@ -127,22 +82,5 @@ class ModuleViewTest extends PHPUnit_Framework_TestCase
         $repository->owner->avatar_url = 'http://www.example.org/img/suzie.gif';
 
         return $repository;
-    }
-
-    /**
-     * @return Entity\Module
-     */
-    private function module()
-    {
-        $module = new Entity\Module();
-
-        $module->setName('foo');
-        $module->setDescription('blah blah');
-        $module->setCreatedAt('1970-01-01 00:00:00');
-        $module->setUrl('http://www.example.org');
-        $module->setOwner('suzie');
-        $module->setPhotoUrl('http://www.example.org/img/suzie.gif');
-
-        return $module;
     }
 }

--- a/module/ZfModule/test/ZfModuleTest/View/Helper/ModuleViewTest.php
+++ b/module/ZfModule/test/ZfModuleTest/View/Helper/ModuleViewTest.php
@@ -3,16 +3,16 @@
 namespace ZfModuleTest\View\Helper;
 
 use PHPUnit_Framework_TestCase;
+use stdClass;
 use Zend\View;
+use ZfModule\Entity;
 use ZfModule\View\Helper;
 
 class ModuleViewTest extends PHPUnit_Framework_TestCase
 {
-    public function testInvokeRendersViewScript()
+    public function testInvokeHandlesRepository()
     {
-        $module = [
-            'foo' => 'bar',
-        ];
+        $repository = $this->repository();
 
         $view = $this->getMockForAbstractClass(View\Renderer\RendererInterface::class);
 
@@ -22,7 +22,41 @@ class ModuleViewTest extends PHPUnit_Framework_TestCase
             ->with(
                 $this->equalTo('zf-module/helper/module-view.phtml'),
                 $this->equalTo([
-                    'module' => $module,
+                    'owner' => $repository->owner->login,
+                    'name' => $repository->name,
+                    'createdAt' => $repository->created_at,
+                    'url' => $repository->html_url,
+                    'photoUrl' => $repository->owner->avatar_url,
+                    'description' => $repository->description,
+                    'button' => 'submit',
+                ])
+            )
+        ;
+
+        $helper = new Helper\ModuleView();
+        $helper->setView($view);
+
+        $helper($repository);
+    }
+
+    public function testInvokeHandlesModule()
+    {
+        $module = $this->module();
+
+        $view = $this->getMockForAbstractClass(View\Renderer\RendererInterface::class);
+
+        $view
+            ->expects($this->once())
+            ->method('render')
+            ->with(
+                $this->equalTo('zf-module/helper/module-view.phtml'),
+                $this->equalTo([
+                    'owner' => $module->getOwner(),
+                    'name' => $module->getName(),
+                    'createdAt' => $module->getCreatedAt(),
+                    'url' => $module->getUrl(),
+                    'photoUrl' => $module->getPhotoUrl(),
+                    'description' => $module->getDescription(),
                     'button' => 'submit',
                 ])
             )
@@ -34,12 +68,24 @@ class ModuleViewTest extends PHPUnit_Framework_TestCase
         $helper($module);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvokeDoesNotHandleAnythingElse()
+    {
+        $module = 'foo';
+
+        $view = $this->getMockForAbstractClass(View\Renderer\RendererInterface::class);
+
+        $helper = new Helper\ModuleView();
+        $helper->setView($view);
+
+        $helper($module);
+    }
+
     public function testInvokeAllowsSpecifyingButtonType()
     {
-        $module = [
-            'foo' => 'bar',
-        ];
-
+        $module = $this->module();
         $button = 'baz';
 
         $view = $this->getMockForAbstractClass(View\Renderer\RendererInterface::class);
@@ -49,10 +95,12 @@ class ModuleViewTest extends PHPUnit_Framework_TestCase
             ->method('render')
             ->with(
                 $this->equalTo('zf-module/helper/module-view.phtml'),
-                $this->equalTo([
-                    'module' => $module,
-                    'button' => $button,
-                ])
+                $this->logicalAnd(
+                    $this->arrayHasKey('button'),
+                    $this->callback(function ($values) use ($button) {
+                        return $values['button'] === $button;
+                    })
+                )
             )
         ;
 
@@ -60,5 +108,41 @@ class ModuleViewTest extends PHPUnit_Framework_TestCase
         $helper->setView($view);
 
         $helper($module, $button);
+    }
+
+    /**
+     * @return stdClass
+     */
+    private function repository()
+    {
+        $repository = new stdClass();
+
+        $repository->name = 'foo';
+        $repository->description = 'blah blah';
+        $repository->created_at = '1970-01-01 00:00:00';
+        $repository->html_url = 'http://www.example.org';
+
+        $repository->owner = new stdClass();
+        $repository->owner->login = 'suzie';
+        $repository->owner->avatar_url = 'http://www.example.org/img/suzie.gif';
+
+        return $repository;
+    }
+
+    /**
+     * @return Entity\Module
+     */
+    private function module()
+    {
+        $module = new Entity\Module();
+
+        $module->setName('foo');
+        $module->setDescription('blah blah');
+        $module->setCreatedAt('1970-01-01 00:00:00');
+        $module->setUrl('http://www.example.org');
+        $module->setOwner('suzie');
+        $module->setPhotoUrl('http://www.example.org/img/suzie.gif');
+
+        return $module;
     }
 }

--- a/module/ZfModule/test/ZfModuleTest/View/Helper/RepositoryTest.php
+++ b/module/ZfModule/test/ZfModuleTest/View/Helper/RepositoryTest.php
@@ -7,7 +7,7 @@ use stdClass;
 use Zend\View;
 use ZfModule\View\Helper;
 
-class ModuleViewTest extends PHPUnit_Framework_TestCase
+class RepositoryTest extends PHPUnit_Framework_TestCase
 {
     public function testInvokeHandlesRepository()
     {
@@ -19,7 +19,7 @@ class ModuleViewTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('render')
             ->with(
-                $this->equalTo('zf-module/helper/module-view.phtml'),
+                $this->equalTo('zf-module/helper/repository.phtml'),
                 $this->equalTo([
                     'owner' => $repository->owner->login,
                     'name' => $repository->name,
@@ -32,7 +32,7 @@ class ModuleViewTest extends PHPUnit_Framework_TestCase
             )
         ;
 
-        $helper = new Helper\ModuleView();
+        $helper = new Helper\Repository();
         $helper->setView($view);
 
         $helper($repository);
@@ -49,7 +49,7 @@ class ModuleViewTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('render')
             ->with(
-                $this->equalTo('zf-module/helper/module-view.phtml'),
+                $this->equalTo('zf-module/helper/repository.phtml'),
                 $this->logicalAnd(
                     $this->arrayHasKey('button'),
                     $this->callback(function ($values) use ($button) {
@@ -59,7 +59,7 @@ class ModuleViewTest extends PHPUnit_Framework_TestCase
             )
         ;
 
-        $helper = new Helper\ModuleView();
+        $helper = new Helper\Repository();
         $helper->setView($view);
 
         $helper($repository, $button);

--- a/module/ZfModule/view/zf-module/helper/module-view.phtml
+++ b/module/ZfModule/view/zf-module/helper/module-view.phtml
@@ -16,13 +16,13 @@
             <div class="col-xs-4">
                 <a href="<?php echo $this->escapeHtmlAttr($url); ?>">Show module on GitHub</a>
                 <hr>
-                <?php if ($button == ZfModule\View\Helper\ModuleView::BUTTON_SUBMIT): ?>
+                <?php if (ZfModule\View\Helper\ModuleView::BUTTON_SUBMIT === $button): ?>
                     <form action="<?php echo $this->url('zf-module/add') ?>" method="post">
                         <input type="hidden" name="owner" value="<?php echo $this->escapeHtmlAttr($owner); ?>" />
                         <input type="hidden" name="repo" value="<?php echo $this->escapeHtmlAttr($name); ?>" />
                         <input type="submit" class="btn btn-success"/>
                     </form>
-                <?php elseif ($button == ZfModule\View\Helper\ModuleView::BUTTON_REMOVE): ?>
+                <?php elseif (ZfModule\View\Helper\ModuleView::BUTTON_REMOVE === $button): ?>
                     <form action="<?php echo $this->url('zf-module/remove') ?>" method="post">
                         <input type="hidden" name="owner" value="<?php echo $this->escapeHtmlAttr($owner); ?>" />
                         <input type="hidden" name="repo" value="<?php echo $this->escapeHtmlAttr($name); ?>" />

--- a/module/ZfModule/view/zf-module/helper/module-view.phtml
+++ b/module/ZfModule/view/zf-module/helper/module-view.phtml
@@ -2,30 +2,30 @@
     <div class="module-info">
         <div class="row">
             <div class="hidden-xs col-sm-2">
-                <img src="<?php echo $this->escapeHtmlAttr($module['photo_url']) ?>" alt="<?php echo $this->escapeHtmlAttr($module['owner']) ?>" class="thumbnail img-responsive">
+                <img src="<?php echo $this->escapeHtmlAttr($photoUrl); ?>" alt="<?php echo $this->escapeHtmlAttr($owner); ?>" class="thumbnail img-responsive">
             </div>
             <div class="col-xs-7 col-sm-6">
                 <p>
-                    <a href="<?php echo $this->url('view-module', ['vendor' => $this->escapeUrl($module['owner']), 'module' => $this->escapeUrl($module['name'])]) ?>">
-                        <strong><?php echo $this->escapeHtml($module['name']) ?></strong>
+                    <a href="<?php echo $this->url('view-module', ['vendor' => $this->escapeUrl($owner), 'module' => $this->escapeUrl($name)]); ?>">
+                        <strong><?php echo $this->escapeHtml($name); ?></strong>
                     </a>
                 </p>
-                <p><span class="zf-green">Submitter:</span> <?php echo $this->escapeHtml($module['owner']) ?></p>
-                <p><span class="zf-green">Created:</span> <?php echo $this->dateFormat(new DateTime($module['created_at']), IntlDateFormatter::SHORT, IntlDateFormatter::SHORT); ?></p>
+                <p><span class="zf-green">Submitter:</span> <?php echo $this->escapeHtml($owner); ?></p>
+                <p><span class="zf-green">Created:</span> <?php echo $this->dateFormat(new DateTime($createdAt), IntlDateFormatter::SHORT, IntlDateFormatter::SHORT); ?></p>
             </div>
             <div class="col-xs-4">
-                <a href="<?php echo $this->escapeHtmlAttr($module['url']) ?>">Show module on GitHub</a>
+                <a href="<?php echo $this->escapeHtmlAttr($url); ?>">Show module on GitHub</a>
                 <hr>
                 <?php if ($button == 'submit'): ?>
                     <form action="<?php echo $this->url('zf-module/add') ?>" method="post">
-                        <input type="hidden" name="owner" value="<?php echo $this->escapeHtmlAttr($module['owner']) ?>" />
-                        <input type="hidden" name="repo" value="<?php echo $this->escapeHtmlAttr($module['name']) ?>" />
+                        <input type="hidden" name="owner" value="<?php echo $this->escapeHtmlAttr($owner); ?>" />
+                        <input type="hidden" name="repo" value="<?php echo $this->escapeHtmlAttr($name); ?>" />
                         <input type="submit" class="btn btn-success"/>
                     </form>
                 <?php else: ?>
                     <form action="<?php echo $this->url('zf-module/remove') ?>" method="post">
-                        <input type="hidden" name="owner" value="<?php echo $this->escapeHtmlAttr($module['owner']) ?>" />
-                        <input type="hidden" name="repo" value="<?php echo $this->escapeHtmlAttr($module['name']) ?>" />
+                        <input type="hidden" name="owner" value="<?php echo $this->escapeHtmlAttr($owner); ?>" />
+                        <input type="hidden" name="repo" value="<?php echo $this->escapeHtmlAttr($name); ?>" />
                         <input type="submit" value="Remove" class="btn btn-danger"/>
                     </form>
                 <?php endif; ?>
@@ -33,6 +33,6 @@
         </div>
     </div>
     <div class="module-description">
-        <p><?php echo $this->escapeHtml($module['description']) ?></p>
+        <p><?php echo $this->escapeHtml($description); ?></p>
     </div>
 </div>

--- a/module/ZfModule/view/zf-module/helper/module-view.phtml
+++ b/module/ZfModule/view/zf-module/helper/module-view.phtml
@@ -16,7 +16,7 @@
             <div class="col-xs-4">
                 <a href="<?php echo $this->escapeHtmlAttr($url); ?>">Show module on GitHub</a>
                 <hr>
-                <?php if ($button == 'submit'): ?>
+                <?php if ($button == ZfModule\View\Helper\ModuleView::BUTTON_SUBMIT): ?>
                     <form action="<?php echo $this->url('zf-module/add') ?>" method="post">
                         <input type="hidden" name="owner" value="<?php echo $this->escapeHtmlAttr($owner); ?>" />
                         <input type="hidden" name="repo" value="<?php echo $this->escapeHtmlAttr($name); ?>" />

--- a/module/ZfModule/view/zf-module/helper/module-view.phtml
+++ b/module/ZfModule/view/zf-module/helper/module-view.phtml
@@ -22,7 +22,7 @@
                         <input type="hidden" name="repo" value="<?php echo $this->escapeHtmlAttr($name); ?>" />
                         <input type="submit" class="btn btn-success"/>
                     </form>
-                <?php else: ?>
+                <?php elseif ($button == ZfModule\View\Helper\ModuleView::BUTTON_REMOVE): ?>
                     <form action="<?php echo $this->url('zf-module/remove') ?>" method="post">
                         <input type="hidden" name="owner" value="<?php echo $this->escapeHtmlAttr($owner); ?>" />
                         <input type="hidden" name="repo" value="<?php echo $this->escapeHtmlAttr($name); ?>" />

--- a/module/ZfModule/view/zf-module/helper/repository.phtml
+++ b/module/ZfModule/view/zf-module/helper/repository.phtml
@@ -16,13 +16,13 @@
             <div class="col-xs-4">
                 <a href="<?php echo $this->escapeHtmlAttr($url); ?>">Show module on GitHub</a>
                 <hr>
-                <?php if (ZfModule\View\Helper\ModuleView::BUTTON_SUBMIT === $button): ?>
+                <?php if (ZfModule\View\Helper\Repository::BUTTON_SUBMIT === $button): ?>
                     <form action="<?php echo $this->url('zf-module/add') ?>" method="post">
                         <input type="hidden" name="owner" value="<?php echo $this->escapeHtmlAttr($owner); ?>" />
                         <input type="hidden" name="repo" value="<?php echo $this->escapeHtmlAttr($name); ?>" />
                         <input type="submit" class="btn btn-success"/>
                     </form>
-                <?php elseif (ZfModule\View\Helper\ModuleView::BUTTON_REMOVE === $button): ?>
+                <?php elseif (ZfModule\View\Helper\Repository::BUTTON_REMOVE === $button): ?>
                     <form action="<?php echo $this->url('zf-module/remove') ?>" method="post">
                         <input type="hidden" name="owner" value="<?php echo $this->escapeHtmlAttr($owner); ?>" />
                         <input type="hidden" name="repo" value="<?php echo $this->escapeHtmlAttr($name); ?>" />

--- a/module/ZfModule/view/zf-module/index/index.phtml
+++ b/module/ZfModule/view/zf-module/index/index.phtml
@@ -3,6 +3,6 @@
     <div class="alert alert-block">No modules found</div>
 <?php else: ?>
     <?php foreach ($repositories as $repository): ?>
-        <?php echo $this->moduleView($repository, ZfModule\View\Helper\ModuleView::BUTTON_SUBMIT); ?>
+        <?php echo $this->repository($repository, ZfModule\View\Helper\Repository::BUTTON_SUBMIT); ?>
     <?php endforeach; ?>
 <?php endif; ?>

--- a/module/ZfModule/view/zf-module/index/index.phtml
+++ b/module/ZfModule/view/zf-module/index/index.phtml
@@ -3,13 +3,6 @@
     <div class="alert alert-block">No modules found</div>
 <?php else: ?>
     <?php foreach ($repositories as $repository): ?>
-        <?php echo $this->moduleView([
-            'owner' => $repository->owner->login,
-            'name' => $repository->name,
-            'created_at' => $repository->created_at,
-            'url' => $repository->html_url,
-            'photo_url' => $repository->owner->avatar_url,
-            'description' => $repository->description
-        ], 'submit') ?>
+        <?php echo $this->moduleView($repository, 'submit'); ?>
     <?php endforeach; ?>
 <?php endif; ?>

--- a/module/ZfModule/view/zf-module/index/index.phtml
+++ b/module/ZfModule/view/zf-module/index/index.phtml
@@ -1,4 +1,4 @@
-<?php /* @var stdClass[] $repositories*/ ?>
+<?php /* @var stdClass[] $repositories */ ?>
 <?php if (!count($repositories)): ?>
     <div class="alert alert-block">No modules found</div>
 <?php else: ?>

--- a/module/ZfModule/view/zf-module/index/index.phtml
+++ b/module/ZfModule/view/zf-module/index/index.phtml
@@ -3,6 +3,6 @@
     <div class="alert alert-block">No modules found</div>
 <?php else: ?>
     <?php foreach ($repositories as $repository): ?>
-        <?php echo $this->moduleView($repository, 'submit'); ?>
+        <?php echo $this->moduleView($repository, ZfModule\View\Helper\ModuleView::BUTTON_SUBMIT); ?>
     <?php endforeach; ?>
 <?php endif; ?>

--- a/module/ZfModule/view/zf-module/index/index.phtml
+++ b/module/ZfModule/view/zf-module/index/index.phtml
@@ -1,5 +1,5 @@
 <?php /* @var stdClass[] $repositories*/ ?>
-<?php if (0 === count($repositories)): ?>
+<?php if (!count($repositories)): ?>
     <div class="alert alert-block">No modules found</div>
 <?php else: ?>
     <?php foreach ($repositories as $repository): ?>

--- a/module/ZfModule/view/zf-module/index/index.phtml
+++ b/module/ZfModule/view/zf-module/index/index.phtml
@@ -1,14 +1,15 @@
-<?php if (empty($this->repositories)): ?>
+<?php /* @var stdClass[] $repositories*/ ?>
+<?php if (0 === count($repositories)): ?>
     <div class="alert alert-block">No modules found</div>
+<?php else: ?>
+    <?php foreach ($repositories as $repository): ?>
+        <?php echo $this->moduleView([
+            'owner' => $repository->owner->login,
+            'name' => $repository->name,
+            'created_at' => $repository->created_at,
+            'url' => $repository->html_url,
+            'photo_url' => $repository->owner->avatar_url,
+            'description' => $repository->description
+        ], 'submit') ?>
+    <?php endforeach; ?>
 <?php endif; ?>
-
-<?php foreach ($repositories as $module): ?>
-    <?php echo $this->moduleView([
-        'owner' => $module->owner->login,
-        'name' => $module->name,
-        'created_at' => $module->created_at,
-        'url' => $module->html_url,
-        'photo_url' => $module->owner->avatar_url,
-        'description' => $module->description
-    ], 'submit') ?>
-<?php endforeach; ?>


### PR DESCRIPTION
This PR aims at simplifying the usage of the `ZfModule\View\Helper\ModuleView` and effectively

* [x] streamlines view templates around usage of the `ModuleView` helper
* [x] refactors the `ModuleView` helper to process an instance of `stdClass` (a repository fetched from GitHub) ~~or an instance of `Entity\Module` (an entity fetched from the database)~~
* [x] extracts constants
* [x] enhances comparison
* [x] refactors `ZfModule\Service\Module::currentUserModules()` to return an array of `stdClass`, technically, repositories registered by the current user, rather than an array of `Entity\Module`
* [x] simplifies the `ModuleView` helper to only process an `stdClass`
* [x] renames the `ModuleView` helper to `Repository` (and matching view script to `repository.phtml`) as it technically renders a presentation of a repository fetched from GitHub 
* [x] renames view and controller variables (for consistency) from `$modules` to `$repositories`
* [x] renames a method for clarity

Follows https://github.com/zendframework/modules.zendframework.com/pull/384#discussion_r24778491.