### PR TITLE
Fix: Remove method which is never used

### DIFF
--- a/module/ZfModule/src/ZfModule/Mapper/Module.php
+++ b/module/ZfModule/src/ZfModule/Mapper/Module.php
@@ -120,11 +120,6 @@ class Module extends AbstractDbMapper implements ModuleInterface
         return $this->findBy('url', $url);
     }
 
-    public function findById($id)
-    {
-        return $this->findBy('module_id', $id);
-    }
-
     public function findBy($key, $value)
     {
         $select = $this->getSelect();

--- a/module/ZfModule/src/ZfModule/Mapper/ModuleInterface.php
+++ b/module/ZfModule/src/ZfModule/Mapper/ModuleInterface.php
@@ -8,8 +8,6 @@ interface ModuleInterface
 
     public function findByUrl($url);
 
-    public function findById($id);
-
     public function insert($module);
 
     public function update($module);


### PR DESCRIPTION
This PR

* [x] removes `ZfModule\Mapper\ModuleInterface::findById()` and its only implementation, as it's never used

:bulb: Not so sure what we'd need `ZfModule\Mapper\ModuleInterface` for, there's currently only one implementation anyway.