### PR TITLE
Fix: Remove plugin configuration for non-existent plugin

### DIFF
--- a/module/ZfModule/config/module.config.php
+++ b/module/ZfModule/config/module.config.php
@@ -4,15 +4,9 @@ use EdpGithub\Client;
 use ZfModule\Controller;
 use ZfModule\Delegators\EdpGithubClientAuthenticator;
 use ZfModule\Mapper\ModuleHydrator;
-use ZfModule\Mvc;
 use ZfModule\View\Helper;
 
 return [
-    'controller_plugins' => [
-        'factories' => [
-            'listModule' => Mvc\Controller\Plugin\ListModuleFactory::class,
-        ],
-    ],
     'controllers'  => [
         'factories' => [
             Controller\IndexController::class => Controller\IndexControllerFactory::class,


### PR DESCRIPTION
This PR

* [x] removes configuration that registers a non-existent controller plugin