### PR TITLE
Fix: When validating repositories, attempt to find by html_url, not by name

### DIFF
--- a/module/ZfModule/src/ZfModule/Service/Module.php
+++ b/module/ZfModule/src/ZfModule/Service/Module.php
@@ -133,7 +133,7 @@ class Module extends EventProvider
                 continue;
             }
 
-            $module = $this->moduleMapper->findByName($repository->name);
+            $module = $this->moduleMapper->findByUrl($repository->html_url);
             if (!($module instanceof Entity\Module)) {
                 continue;
             }

--- a/module/ZfModule/test/ZfModuleTest/Service/ModuleTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Service/ModuleTest.php
@@ -81,13 +81,7 @@ class ModuleTest extends PHPUnit_Framework_TestCase
 
     public function testListUserModulesListsCurrentUsersModulesFromApiFoundInDatabase()
     {
-        $name = 'foo';
-
-        $repository = new stdClass();
-        $repository->fork = false;
-        $repository->permissions = new stdClass();
-        $repository->permissions->push = true;
-        $repository->name = $name;
+        $repository = $this->repository();
 
         $module = $this->getMockBuilder(Entity\Module::class)->getMock();
 
@@ -100,7 +94,7 @@ class ModuleTest extends PHPUnit_Framework_TestCase
         $moduleMapper
             ->expects($this->once())
             ->method('findByName')
-            ->with($this->equalTo($name))
+            ->with($this->equalTo($repository->name))
             ->willReturn($module)
         ;
 
@@ -135,9 +129,8 @@ class ModuleTest extends PHPUnit_Framework_TestCase
 
     public function testListUserModulesDoesNotLookupModulesFromApiWhereUserHasNoPushPrivilege()
     {
-        $repository = new stdClass();
-        $repository->fork = false;
-        $repository->permissions = new stdClass();
+        $repository = $this->repository();
+
         $repository->permissions->push = false;
 
         $moduleMapper = $this->getMockBuilder(Mapper\Module::class)->getMock();
@@ -178,7 +171,8 @@ class ModuleTest extends PHPUnit_Framework_TestCase
 
     public function testListUserModulesDoesNotLookupModulesFromApiThatAreForks()
     {
-        $repository = new stdClass();
+        $repository = $this->repository();
+
         $repository->fork = true;
 
         $moduleMapper = $this->getMockBuilder(Mapper\Module::class)->getMock();
@@ -219,20 +213,14 @@ class ModuleTest extends PHPUnit_Framework_TestCase
 
     public function testListUserModulesDoesNotListModulesFromApiNotFoundInDatabase()
     {
-        $name = 'foo';
-
-        $repository = new stdClass();
-        $repository->fork = false;
-        $repository->permissions = new stdClass();
-        $repository->permissions->push = true;
-        $repository->name = $name;
+        $repository = $this->repository();
 
         $moduleMapper = $this->getMockBuilder(Mapper\Module::class)->getMock();
 
         $moduleMapper
             ->expects($this->once())
             ->method('findByName')
-            ->with($this->equalTo($name))
+            ->with($this->equalTo($repository->name))
             ->willReturn(false)
         ;
 

--- a/module/ZfModule/test/ZfModuleTest/Service/ModuleTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Service/ModuleTest.php
@@ -93,8 +93,8 @@ class ModuleTest extends PHPUnit_Framework_TestCase
 
         $moduleMapper
             ->expects($this->once())
-            ->method('findByName')
-            ->with($this->equalTo($repository->name))
+            ->method('findByUrl')
+            ->with($this->equalTo($repository->html_url))
             ->willReturn($module)
         ;
 
@@ -137,7 +137,7 @@ class ModuleTest extends PHPUnit_Framework_TestCase
 
         $moduleMapper
             ->expects($this->never())
-            ->method('findByName')
+            ->method('findByUrl')
         ;
 
         $currentUserService = $this->getMockBuilder(Api\CurrentUser::class)->getMock();
@@ -179,7 +179,7 @@ class ModuleTest extends PHPUnit_Framework_TestCase
 
         $moduleMapper
             ->expects($this->never())
-            ->method('findByName')
+            ->method('findByUrl')
         ;
 
         $currentUserService = $this->getMockBuilder(Api\CurrentUser::class)->getMock();
@@ -219,8 +219,8 @@ class ModuleTest extends PHPUnit_Framework_TestCase
 
         $moduleMapper
             ->expects($this->once())
-            ->method('findByName')
-            ->with($this->equalTo($repository->name))
+            ->method('findByUrl')
+            ->with($this->equalTo($repository->html_url))
             ->willReturn(false)
         ;
 


### PR DESCRIPTION
This PR

* [x] enhances tests covering `ZfModule\Service\Module` by re-using repository provider method `repository()`
* [x] fixes an issue where when validating repositories fetched from GitHub, the mapper would look up modules by name, not url, and in result, render other's modules under your account

Fixes #128.
Fixes #199.
Fixes #246.

### Steps required to reproduce

* create a repository on GitHub with the same name as a registered on, e.g., `ZF2-AcYaml` https://github.com/acelaya/ZF2-AcYaml, I did here https://github.com/localheinz/ZF2-AcYaml
* sign in with GitHub to http://modules.zendframework.com
* navigate to http://modules.zendframework.com/user

### Before

![screen shot 2015-02-17 at 22 52 27](https://cloud.githubusercontent.com/assets/605483/6238404/fbb04ff8-b6fa-11e4-8e0a-90c32de28828.png)

### After

![screen shot 2015-02-17 at 23 15 57](https://cloud.githubusercontent.com/assets/605483/6238407/031eb8f6-b6fb-11e4-98a2-4f7e12510f39.png)


