### PR TITLE
Enhancement: Also search by owner, split query into words

### DIFF
--- a/module/Application/view/application/index/index.phtml
+++ b/module/Application/view/application/index/index.phtml
@@ -22,10 +22,9 @@
                         <div class="col-xs-7 col-sm-6">
                             <p>
                                 <a href="<?php echo $this->url('view-module', ['vendor' => $this->escapeUrl($module->getOwner()), 'module' => $this->escapeUrl($module->getName())]) ?>">
-                                    <strong><?php echo $this->escapeHtml($module->getName()) ?></strong>
+                                    <strong><?php echo $this->escapeHtml($module->getOwner()); ?>/<?php echo $this->escapeHtml($module->getName()); ?></strong>
                                 </a>
                             </p>
-                            <p><span class="zf-green">Submitter:</span> <?php echo $this->escapeHtml($module->getOwner()) ?></p>
                             <p><span class="zf-green">Created:</span> <?php echo $this->dateFormat($module->getCreatedAtDateTime(), IntlDateFormatter::SHORT, IntlDateFormatter::SHORT); ?></p>
                         </div>
                         <div class="col-xs-4">

--- a/module/Application/view/application/search/index.phtml
+++ b/module/Application/view/application/search/index.phtml
@@ -1,16 +1,16 @@
+<?php /* @var ZfModule\Entity\Module[] $results */ ?>
 <?php if (count($results) >= 1): ?>
-    <?php /* @var ZfModule\Entity\Module[] $results*/ ?>
     <?php foreach ($results as $module): ?>
         <div class="media">
             <div class="media-left">
-                <a href="<?php echo $this->url('view-module', ['vendor' => $this->escapeUrl($module->getOwner()), 'module' => $this->escapeUrl($module->getName())]) ?>">
-                    <img width="50" src="<?php echo $this->escapeHtmlAttr($module->getPhotoUrl()) ?>" alt="<?php echo $this->escapeHtmlAttr($module->getName()) ?>" class="media-object">
+                <a href="<?php echo $this->url('view-module', ['vendor' => $this->escapeUrl($module->getOwner()), 'module' => $this->escapeUrl($module->getName())]); ?>">
+                    <img width="50" src="<?php echo $this->escapeHtmlAttr($module->getPhotoUrl()); ?>" alt="<?php echo $this->escapeHtmlAttr($module->getName()); ?>" class="media-object">
                 </a>
             </div>
             <div class="media-body">
                 <h4 class="media-heading">
-                    <a href="<?php echo $this->url('view-module', ['vendor' => $this->escapeUrl($module->getOwner()), 'module' => $this->escapeUrl($module->getName())]) ?>">
-                        <?php echo $this->escapeHtml($module->getName()) ?>
+                    <a href="<?php echo $this->url('view-module', ['vendor' => $this->escapeUrl($module->getOwner()), 'module' => $this->escapeUrl($module->getName())]); ?>">
+                        <?php echo $this->escapeHtml($module->getOwner()); ?>/<?php echo $this->escapeHtml($module->getName()); ?>
                     </a>
                 </h4>
                 <?php echo $this->escapeHtml($module->getDescription()) ?>

--- a/module/ZfModule/src/ZfModule/Mapper/Module.php
+++ b/module/ZfModule/src/ZfModule/Mapper/Module.php
@@ -89,7 +89,7 @@ class Module extends AbstractDbMapper implements ModuleInterface
             $like = '%' . $query . '%';
 
             /* @var Sql\Where $where */
-            $where->like('name', $like)->or->like('description', $like);
+            $where->like('name', $like)->or->like('description', $like)->or->like('owner', $like);
         });
     }
 

--- a/module/ZfModule/src/ZfModule/Mapper/Module.php
+++ b/module/ZfModule/src/ZfModule/Mapper/Module.php
@@ -31,11 +31,10 @@ class Module extends AbstractDbMapper implements ModuleInterface
         }
 
         if (null !== $query) {
-            $spec = function ($where) use ($query) {
+            $select->where(function ($where) use ($query) {
                 /* @var Sql\Where $where */
                 $where->like('name', '%' . $query . '%')->or->like('description', '%' . $query . '%');
-            };
-            $select->where($spec);
+            });
         }
         $resultSet = new HydratingResultSet($this->getHydrator(), $this->getEntityPrototype());
 
@@ -78,11 +77,10 @@ class Module extends AbstractDbMapper implements ModuleInterface
             $select->limit($limit);
         }
 
-        $spec = function ($where) use ($query) {
+        $select->where(function ($where) use ($query) {
             /* @var Sql\Where $where */
             $where->like('name', '%' . $query . '%')->or->like('description', '%' . $query . '%');
-        };
-        $select->where($spec);
+        });
 
         $entity = $this->select($select);
         $this->getEventManager()->trigger('find', $this, ['entity' => $entity]);

--- a/module/ZfModule/src/ZfModule/Mapper/Module.php
+++ b/module/ZfModule/src/ZfModule/Mapper/Module.php
@@ -85,6 +85,12 @@ class Module extends AbstractDbMapper implements ModuleInterface
 
     private function whereLike(Sql\Select $select, $query)
     {
+        $query = preg_replace('/\s+/', ' ', $query);
+
+        if (!trim($query)) {
+            return;
+        }
+
         $words = explode(' ', $query);
 
         $select->where(function ($where) use ($words) {

--- a/module/ZfModule/src/ZfModule/Mapper/Module.php
+++ b/module/ZfModule/src/ZfModule/Mapper/Module.php
@@ -32,8 +32,10 @@ class Module extends AbstractDbMapper implements ModuleInterface
 
         if (null !== $query) {
             $select->where(function ($where) use ($query) {
+                $like = '%' . $query . '%';
+
                 /* @var Sql\Where $where */
-                $where->like('name', '%' . $query . '%')->or->like('description', '%' . $query . '%');
+                $where->like('name', $like)->or->like('description', $like);
             });
         }
         $resultSet = new HydratingResultSet($this->getHydrator(), $this->getEntityPrototype());
@@ -78,8 +80,10 @@ class Module extends AbstractDbMapper implements ModuleInterface
         }
 
         $select->where(function ($where) use ($query) {
+            $like = '%' . $query . '%';
+
             /* @var Sql\Where $where */
-            $where->like('name', '%' . $query . '%')->or->like('description', '%' . $query . '%');
+            $where->like('name', $like)->or->like('description', $like);
         });
 
         $entity = $this->select($select);

--- a/module/ZfModule/src/ZfModule/Mapper/Module.php
+++ b/module/ZfModule/src/ZfModule/Mapper/Module.php
@@ -85,11 +85,21 @@ class Module extends AbstractDbMapper implements ModuleInterface
 
     private function whereLike(Sql\Select $select, $query)
     {
-        $select->where(function ($where) use ($query) {
-            $like = '%' . $query . '%';
+        $words = explode(' ', $query);
 
-            /* @var Sql\Where $where */
-            $where->like('name', $like)->or->like('description', $like)->or->like('owner', $like);
+        $select->where(function ($where) use ($words) {
+
+            foreach ($words as $word) {
+                $like = '%' . $word . '%';
+
+                /* @var Sql\Where $where */
+                $where
+                    ->nest()
+                    ->like('name', $like)->or
+                    ->like('description', $like)->or
+                    ->like('owner', $like)
+                    ->unnest();
+            }
         });
     }
 

--- a/module/ZfModule/src/ZfModule/Mapper/Module.php
+++ b/module/ZfModule/src/ZfModule/Mapper/Module.php
@@ -3,7 +3,7 @@
 namespace ZfModule\Mapper;
 
 use Zend\Db\ResultSet\HydratingResultSet;
-use Zend\Db\Sql\Expression;
+use Zend\Db\Sql;
 use Zend\Paginator\Adapter\DbSelect;
 use Zend\Paginator\Paginator;
 use Zend\Stdlib\Hydrator\HydratorInterface;
@@ -32,6 +32,7 @@ class Module extends AbstractDbMapper implements ModuleInterface
 
         if (null !== $query) {
             $spec = function ($where) use ($query) {
+                /* @var Sql\Where $where */
                 $where->like('name', '%' . $query . '%')->or->like('description', '%' . $query . '%');
             };
             $select->where($spec);
@@ -78,6 +79,7 @@ class Module extends AbstractDbMapper implements ModuleInterface
         }
 
         $spec = function ($where) use ($query) {
+            /* @var Sql\Where $where */
             $where->like('name', '%' . $query . '%')->or->like('description', '%' . $query . '%');
         };
         $select->where($spec);
@@ -160,7 +162,7 @@ class Module extends AbstractDbMapper implements ModuleInterface
     public function getTotal()
     {
         $select = $this->getSelect();
-        $select->columns(['num' => new Expression('COUNT(*)')]);
+        $select->columns(['num' => new Sql\Expression('COUNT(*)')]);
 
         $stmt = $this->getSlaveSql()->prepareStatementForSqlObject($select);
         $row = $stmt->execute()->current();

--- a/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleTest.php
@@ -102,6 +102,9 @@ class ModuleTest extends PHPUnit_Framework_TestCase
             [
                 'description',
             ],
+            [
+                'owner',
+            ],
         ];
     }
 

--- a/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleTest.php
@@ -4,6 +4,8 @@ namespace ZfModuleTest\Integration\Mapper;
 
 use ApplicationTest\Integration\Util\Bootstrap;
 use PHPUnit_Framework_TestCase;
+use Zend\Db;
+use ZfModule\Entity;
 use ZfModule\Mapper;
 
 /**
@@ -11,13 +13,92 @@ use ZfModule\Mapper;
  */
 class ModuleTest extends PHPUnit_Framework_TestCase
 {
-    public function testCanRetrieveService()
+    /**
+     * @var Mapper\Module
+     */
+    private $mapper;
+
+    /**
+     * @var Db\Adapter\Driver\ConnectionInterface
+     */
+    private $connection;
+
+    protected function setUp()
     {
         $serviceManager = Bootstrap::getServiceManager();
 
-        $this->assertInstanceOf(
-            Mapper\Module::class,
-            $serviceManager->get(Mapper\Module::class)
-        );
+        $this->mapper = $serviceManager->get(Mapper\Module::class);
+
+        /* @var Db\Adapter\Adapter $database */
+        $database = $serviceManager->get('zfcuser_zend_db_adapter');
+
+        $this->connection = $database->getDriver()->getConnection();
+        $this->connection->beginTransaction();
+    }
+
+    protected function tearDown()
+    {
+        $this->connection->rollback();
+
+        unset($this->mapper);
+        unset($this->connection);
+    }
+
+    /**
+     * @dataProvider providerProperties
+     *
+     * @param $property
+     */
+    public function testPaginationFindsInProperty($property)
+    {
+        $value = 'foo bar baz';
+        $query = 'bar';
+
+        $module = $this->module();
+
+        $setter = 'set' . ucfirst($property);
+
+        $module->{$setter}($value);
+
+        $this->mapper->insert($module);
+
+        $paginator = $this->mapper->pagination(1, 100, $query);
+
+        $this->assertSame(1, $paginator->getTotalItemCount());
+    }
+
+    /**
+     * @return array
+     */
+    public function providerProperties()
+    {
+        return [
+            [
+                'name',
+            ],
+            [
+                'description',
+            ],
+        ];
+    }
+
+    /**
+     * @return Entity\Module
+     */
+    private function module()
+    {
+        static $id = 1;
+
+        $module = new Entity\Module();
+
+        $module->setId($id);
+        $module->setName('');
+        $module->setOwner('');
+        $module->setDescription('');
+        $module->setUrl('');
+
+        $id++;
+
+        return $module;
     }
 }

--- a/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleTest.php
@@ -174,6 +174,9 @@ class ModuleTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @todo Id shouldn't need to be set, but currently missing auto_increment
+     * @link https://github.com/zendframework/modules.zendframework.com/pull/340
+     *
      * @return Entity\Module
      */
     private function module()

--- a/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleTest.php
@@ -64,7 +64,10 @@ class ModuleTest extends PHPUnit_Framework_TestCase
 
         $paginator = $this->mapper->pagination(1, 100, $query);
 
-        $this->assertSame(1, $paginator->getTotalItemCount());
+        /* @var Db\ResultSet\HydratingResultSet $resultSet */
+        $resultSet = $paginator->getCurrentItems();
+
+        $this->assertCount(1, $resultSet);
     }
 
     /**
@@ -85,9 +88,10 @@ class ModuleTest extends PHPUnit_Framework_TestCase
 
         $this->mapper->insert($module);
 
-        $results = $this->mapper->findByLike($query);
+        /* @var Db\ResultSet\HydratingResultSet $resultSet */
+        $resultSet = $this->mapper->findByLike($query);
 
-        $this->assertCount(1, $results);
+        $this->assertCount(1, $resultSet);
     }
 
     /**

--- a/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleTest.php
@@ -68,6 +68,29 @@ class ModuleTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider providerProperties
+     *
+     * @param $property
+     */
+    public function testFindByLikeFindsInProperty($property)
+    {
+        $value = 'foo bar baz';
+        $query = 'bar';
+
+        $module = $this->module();
+
+        $setter = 'set' . ucfirst($property);
+
+        $module->{$setter}($value);
+
+        $this->mapper->insert($module);
+
+        $results = $this->mapper->findByLike($query);
+
+        $this->assertCount(1, $results);
+    }
+
+    /**
      * @return array
      */
     public function providerProperties()

--- a/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleTest.php
@@ -112,6 +112,67 @@ class ModuleTest extends PHPUnit_Framework_TestCase
         ];
     }
 
+    public function testPaginationMatchesEntitiesWhereAllWordsExist()
+    {
+        $value = 'foo bar baz qux';
+        $query = 'foo baz';
+
+        $module = $this->module();
+        $module->setDescription($value);
+        $this->mapper->insert($module);
+
+        $moduleFoo = $this->module();
+        $moduleFoo->setDescription('foo');
+        $this->mapper->insert($moduleFoo);
+
+        $moduleBaz = $this->module();
+        $moduleBaz->setDescription('baz');
+        $this->mapper->insert($moduleBaz);
+
+        $paginator = $this->mapper->pagination(1, 100, $query);
+
+        /* @var Db\ResultSet\HydratingResultSet $resultSet */
+        $resultSet = $paginator->getCurrentItems();
+
+        $this->assertCount(1, $resultSet);
+
+        /* @var Entity\Module $result */
+        $result = $resultSet->current();
+
+        $this->assertInstanceOf(Entity\Module::class, $result);
+        $this->assertSame($result->getDescription(), $module->getDescription());
+    }
+
+    public function testFindByLikeMatchesEntitiesWhereAllWordsExist()
+    {
+        $value = 'foo bar baz qux';
+        $query = 'foo baz';
+
+        $module = $this->module();
+        $module->setDescription($value);
+        $this->mapper->insert($module);
+
+        $moduleFoo = $this->module();
+        $moduleFoo->setDescription('foo');
+        $this->mapper->insert($moduleFoo);
+
+        $moduleBaz = $this->module();
+        $moduleBaz->setDescription('baz');
+        $this->mapper->insert($moduleBaz);
+
+        /* @var Db\ResultSet\HydratingResultSet $resultSet */
+        $resultSet = $this->mapper->findByLike($query);
+
+        $this->assertCount(1, $resultSet);
+
+        /* @var Entity\Module $result */
+        $result = $resultSet->current();
+
+        $this->assertInstanceOf(Entity\Module::class, $result);
+
+        $this->assertSame($result->getDescription(), $module->getDescription());
+    }
+
     /**
      * @return Entity\Module
      */

--- a/module/ZfModule/view/zf-module/helper/new-module.phtml
+++ b/module/ZfModule/view/zf-module/helper/new-module.phtml
@@ -9,10 +9,8 @@
             </div>
             <div class="col-md-9">
                 <a href="<?php echo $this->url('view-module', ['vendor' => $this->escapeUrl($module->getOwner()), 'module' => $this->escapeUrl($module->getName())]) ?>">
-                    <?php echo $this->escapeHtml($module->getName()); ?>
+                    <?php echo $this->escapeHtml($module->getOwner()); ?>/<?php echo $this->escapeHtml($module->getName()); ?>
                 </a>
-                <br>
-                <strong>Author:</strong> <?php echo $this->escapeHtml($module->getOwner()) ?>
             </div>
         </div>
         <hr>


### PR DESCRIPTION
This PR

* [x] cleans up `ZfModule\Mapper\Module` a bit
* [x] improves the search by not only looking for matches in `name` and `description`, but also in `owner`
* [x] improves the search by exploding the search query by ` ` and using the parts for searching

Fixes #153.

## Searching by owner

### Before

![screen shot 2015-02-18 at 10 34 59](https://cloud.githubusercontent.com/assets/605483/6244989/52d454dc-b75a-11e4-8b4e-3e370b46e627.png)

### After

![screen shot 2015-02-18 at 15 50 43](https://cloud.githubusercontent.com/assets/605483/6249200/f3ecd7ba-b785-11e4-893e-a8e368456e8b.png)

## Searching with multiple words

## Before

![screen shot 2015-02-18 at 15 22 18](https://cloud.githubusercontent.com/assets/605483/6248665/1f5dd9ac-b782-11e4-9701-52cb2ac46d3c.png)

## After

![screen shot 2015-02-18 at 15 49 50](https://cloud.githubusercontent.com/assets/605483/6249185/d9094366-b785-11e4-8137-f5a24119cf39.png)

## Display of vendor/package vs just package

### Before

![screen shot 2015-02-18 at 15 44 55](https://cloud.githubusercontent.com/assets/605483/6249091/2248791c-b785-11e4-9bcb-4bed993000c2.png)

### After

![screen shot 2015-02-18 at 15 43 35](https://cloud.githubusercontent.com/assets/605483/6249096/2b52ba68-b785-11e4-82bc-12af6598dada.png)
