### PR TITLE
Enhancement: Use class keyword as service identifier in ZfModule module

### DIFF
--- a/module/Application/src/Application/Controller/IndexControllerFactory.php
+++ b/module/Application/src/Application/Controller/IndexControllerFactory.php
@@ -26,7 +26,7 @@ class IndexControllerFactory implements FactoryInterface
         $serviceManager = $controllerManager->getServiceLocator();
 
         /* @var Mapper\Module $moduleMapper */
-        $moduleMapper = $serviceManager->get('zfmodule_mapper_module');
+        $moduleMapper = $serviceManager->get(Mapper\Module::class);
 
         return new IndexController($moduleMapper);
     }

--- a/module/Application/src/Application/Controller/SearchControllerFactory.php
+++ b/module/Application/src/Application/Controller/SearchControllerFactory.php
@@ -26,7 +26,7 @@ class SearchControllerFactory implements FactoryInterface
         $serviceManager = $controllerManager->getServiceLocator();
 
         /* @var Mapper\Module $moduleMapper */
-        $moduleMapper = $serviceManager->get('zfmodule_mapper_module');
+        $moduleMapper = $serviceManager->get(Mapper\Module::class);
 
         return new SearchController($moduleMapper);
     }

--- a/module/Application/test/ApplicationTest/Integration/Controller/IndexControllerTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Controller/IndexControllerTest.php
@@ -8,7 +8,7 @@ use User\Mapper\User;
 use Zend\Http;
 use Zend\Paginator;
 use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
-use ZfModule\Mapper\Module;
+use ZfModule\Mapper;
 
 class IndexControllerTest extends AbstractHttpControllerTestCase
 {
@@ -21,7 +21,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
     public function testIndexActionCanBeAccessed()
     {
-        $moduleMapper = $this->getMockBuilder(Module::class)->getMock();
+        $moduleMapper = $this->getMockBuilder(Mapper\Module::class)->getMock();
 
         $moduleMapper
             ->expects($this->once())
@@ -69,7 +69,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $this->getApplicationServiceLocator()
             ->setAllowOverride(true)
             ->setService(
-                'zfmodule_mapper_module',
+                Mapper\Module::class,
                 $moduleMapper
             )
             ->setService(
@@ -87,7 +87,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
     public function testFeedActionCanBeAccessed()
     {
-        $moduleMapper = $this->getMockBuilder(Module::class)->getMock();
+        $moduleMapper = $this->getMockBuilder(Mapper\Module::class)->getMock();
 
         $moduleMapper
             ->expects($this->once())
@@ -105,7 +105,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $this->getApplicationServiceLocator()
             ->setAllowOverride(true)
             ->setService(
-                'zfmodule_mapper_module',
+                Mapper\Module::class,
                 $moduleMapper
             )
         ;

--- a/module/Application/test/ApplicationTest/Integration/Controller/SearchControllerTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Controller/SearchControllerTest.php
@@ -31,7 +31,7 @@ class SearchControllerTest extends AbstractHttpControllerTestCase
         $this->getApplicationServiceLocator()
             ->setAllowOverride(true)
             ->setService(
-                'zfmodule_mapper_module',
+                Mapper\Module::class,
                 $moduleMapper
             )
         ;

--- a/module/User/src/User/Controller/UserControllerFactory.php
+++ b/module/User/src/User/Controller/UserControllerFactory.php
@@ -19,7 +19,7 @@ class UserControllerFactory implements FactoryInterface
         $serviceManager = $controllerManager->getServiceLocator();
 
         /* @var Service\Module $moduleService */
-        $moduleService = $serviceManager->get('zfmodule_service_module');
+        $moduleService = $serviceManager->get(Service\Module::class);
 
         return new UserController($moduleService);
     }

--- a/module/User/test/UserTest/Integration/Controller/UserControllerTest.php
+++ b/module/User/test/UserTest/Integration/Controller/UserControllerTest.php
@@ -57,7 +57,7 @@ class UserControllerTest extends AbstractHttpControllerTestCase
         $serviceManager
             ->setAllowOverride(true)
             ->setService(
-                'zfmodule_service_module',
+                Service\Module::class,
                 $moduleService
             )
         ;

--- a/module/ZfModule/config/module.config.php
+++ b/module/ZfModule/config/module.config.php
@@ -3,7 +3,8 @@
 use EdpGithub\Client;
 use ZfModule\Controller;
 use ZfModule\Delegators\EdpGithubClientAuthenticator;
-use ZfModule\Mapper\ModuleHydrator;
+use ZfModule\Mapper;
+use ZfModule\Service;
 use ZfModule\View\Helper;
 
 return [
@@ -87,11 +88,11 @@ return [
     ],
     'service_manager' => [
         'invokables' => [
-            ModuleHydrator::class => ModuleHydrator::class,
+            Mapper\ModuleHydrator::class => Mapper\ModuleHydrator::class,
         ],
         'factories' => [
-            'zfmodule_service_module' => ZfModule\Service\ModuleFactory::class,
-            'zfmodule_mapper_module' => ZfModule\Mapper\ModuleFactory::class,
+            Mapper\Module::class => Mapper\ModuleFactory::class,
+            Service\Module::class => Service\ModuleFactory::class,
         ],
         'delegators' => [
             Client::class => [

--- a/module/ZfModule/src/ZfModule/Controller/IndexControllerFactory.php
+++ b/module/ZfModule/src/ZfModule/Controller/IndexControllerFactory.php
@@ -21,10 +21,10 @@ class IndexControllerFactory implements FactoryInterface
         $serviceManager = $controllerManager->getServiceLocator();
 
         /* @var Mapper\Module $moduleMapper */
-        $moduleMapper = $serviceManager->get('zfmodule_mapper_module');
+        $moduleMapper = $serviceManager->get(Mapper\Module::class);
 
         /* @var Service\Module $moduleService */
-        $moduleService = $serviceManager->get('zfmodule_service_module');
+        $moduleService = $serviceManager->get(Service\Module::class);
 
         /* @var RepositoryRetriever $repositoryRetriever */
         $repositoryRetriever = $serviceManager->get(RepositoryRetriever::class);

--- a/module/ZfModule/src/ZfModule/Service/ModuleFactory.php
+++ b/module/ZfModule/src/ZfModule/Service/ModuleFactory.php
@@ -17,7 +17,7 @@ class ModuleFactory implements FactoryInterface
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         /* @var Mapper\Module $moduleMapper */
-        $moduleMapper = $serviceLocator->get('zfmodule_mapper_module');
+        $moduleMapper = $serviceLocator->get(Mapper\Module::class);
 
         /* @var Client $githubClient */
         $githubClient = $serviceLocator->get('EdpGithub\Client');

--- a/module/ZfModule/src/ZfModule/View/Helper/NewModuleFactory.php
+++ b/module/ZfModule/src/ZfModule/View/Helper/NewModuleFactory.php
@@ -20,7 +20,7 @@ class NewModuleFactory implements FactoryInterface
         $serviceManager = $helperPluginManager->getServiceLocator();
 
         /* @var Mapper\Module $moduleMapper */
-        $moduleMapper = $serviceManager->get('zfmodule_mapper_module');
+        $moduleMapper = $serviceManager->get(Mapper\Module::class);
 
         return new NewModule($moduleMapper);
     }

--- a/module/ZfModule/src/ZfModule/View/Helper/TotalModulesFactory.php
+++ b/module/ZfModule/src/ZfModule/View/Helper/TotalModulesFactory.php
@@ -20,7 +20,7 @@ class TotalModulesFactory implements FactoryInterface
         $serviceManager = $helperPluginManager->getServiceLocator();
 
         /* @var Mapper\Module $moduleMapper */
-        $moduleMapper = $serviceManager->get('zfmodule_mapper_module');
+        $moduleMapper = $serviceManager->get(Mapper\Module::class);
 
         return new TotalModules($moduleMapper);
     }

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -155,11 +155,11 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
                 $repositoryRetriever
             )
             ->setService(
-                'zfmodule_service_module',
+                Service\Module::class,
                 $moduleService
             )
             ->setService(
-                'zfmodule_mapper_module',
+                Mapper\Module::class,
                 $moduleMapper
             )
         ;
@@ -363,11 +363,11 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
                 $repositoryRetriever
             )
             ->setService(
-                'zfmodule_service_module',
+                Service\Module::class,
                 $moduleService
             )
             ->setService(
-                'zfmodule_mapper_module',
+                Mapper\Module::class,
                 $moduleMapper
             )
         ;
@@ -1063,7 +1063,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $this->getApplicationServiceLocator()
             ->setAllowOverride(true)
             ->setService(
-                'zfmodule_mapper_module',
+                Mapper\Module::class,
                 $moduleMapper
             )
         ;
@@ -1116,7 +1116,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $this->getApplicationServiceLocator()
             ->setAllowOverride(true)
             ->setService(
-                'zfmodule_mapper_module',
+                Mapper\Module::class,
                 $moduleMapper
             )
             ->setService(
@@ -1173,7 +1173,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         $this->getApplicationServiceLocator()
             ->setAllowOverride(true)
             ->setService(
-                'zfmodule_mapper_module',
+                Mapper\Module::class,
                 $moduleMapper
             )
             ->setService(

--- a/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleHydratorTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleHydratorTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ZfModuleTest\Integration\Mapper;
+
+use ApplicationTest\Integration\Util\Bootstrap;
+use PHPUnit_Framework_TestCase;
+use ZfModule\Mapper;
+
+/**
+ * @coversNothing
+ */
+class ModuleHydratorTest extends PHPUnit_Framework_TestCase
+{
+    public function testCanRetrieveService()
+    {
+        $serviceManager = Bootstrap::getServiceManager();
+
+        $this->assertInstanceOf(
+            Mapper\ModuleHydrator::class,
+            $serviceManager->get(Mapper\ModuleHydrator::class)
+        );
+    }
+}

--- a/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ZfModuleTest\Integration\Mapper;
+
+use ApplicationTest\Integration\Util\Bootstrap;
+use PHPUnit_Framework_TestCase;
+use ZfModule\Mapper;
+
+/**
+ * @coversNothing
+ */
+class ModuleTest extends PHPUnit_Framework_TestCase
+{
+    public function testCanRetrieveService()
+    {
+        $serviceManager = Bootstrap::getServiceManager();
+
+        $this->assertInstanceOf(
+            Mapper\Module::class,
+            $serviceManager->get('zfmodule_mapper_module')
+        );
+    }
+}

--- a/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleTest.php
@@ -17,7 +17,7 @@ class ModuleTest extends PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(
             Mapper\Module::class,
-            $serviceManager->get('zfmodule_mapper_module')
+            $serviceManager->get(Mapper\Module::class)
         );
     }
 }

--- a/module/ZfModule/test/ZfModuleTest/Integration/Service/ModuleTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Service/ModuleTest.php
@@ -17,7 +17,7 @@ class ModuleTest extends PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(
             Service\Module::class,
-            $serviceManager->get('zfmodule_service_module')
+            $serviceManager->get(Service\Module::class)
         );
     }
 }

--- a/module/ZfModule/test/ZfModuleTest/Integration/Service/ModuleTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Service/ModuleTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace ZfModuleTest\Integration\Service;
+
+use ApplicationTest\Integration\Util\Bootstrap;
+use PHPUnit_Framework_TestCase;
+use ZfModule\Service;
+
+/**
+ * @coversNothing
+ */
+class ModuleTest extends PHPUnit_Framework_TestCase
+{
+    public function testCanRetrieveService()
+    {
+        $serviceManager = Bootstrap::getServiceManager();
+
+        $this->assertInstanceOf(
+            Service\Module::class,
+            $serviceManager->get('zfmodule_service_module')
+        );
+    }
+}


### PR DESCRIPTION
This PR

* [x] asserts that services can be retrieved
* [x] uses the `class` keyword as service identifier for these services