### PR TITLE
Enhancement: Streamline layouts and fix-up content

### DIFF
--- a/module/Application/view/layout/layout-small-header.phtml
+++ b/module/Application/view/layout/layout-small-header.phtml
@@ -35,7 +35,7 @@
                         <?php $identity = $this->zfcUserIdentity(); ?>
                         <div class="gravatar-container">
                             <a class="login" href="<?php echo $this->url('zfcuser'); ?>" title="My profile">
-                                <img src="<?php echo $this->escapeHtmlAttr($identity->getPhotoUrl()); ?>" alt="<?php echo $this->escapeHtmlAttr($this->zfcUserDisplayName()); ?>" style="width:23px;height:23px;" />
+                                <img src="<?php echo $this->escapeHtmlAttr($identity->getPhotoUrl()); ?>" alt="<?php echo $this->escapeHtmlAttr($this->zfcUserDisplayName()); ?>" style="width:23px;height:23px;">
                             </a>
                         </div>
                         <a class="login" href="<?php echo $this->url('zfcuser'); ?>" title="My profile"> Hello <?php echo $this->escapeHtml(ucfirst($userDisplayName)); ?></a>
@@ -59,7 +59,7 @@
                 <div class="row">
                     <div class="col-md-8">
                         <a href="<?php echo $this->url('home'); ?>" style="text-decoration:none">
-                            <img src="<?php echo $this->basePath('/img/zend-logo_small.png'); ?>" alt="ZF Modules"/>
+                            <img src="<?php echo $this->basePath('/img/zend-logo_small.png'); ?>" alt="ZF Modules">
                             <p class="zf-green">
                                 Modules
                             </p>
@@ -76,7 +76,7 @@
             </div>
         </div>
 
-        <hr style="clear:both" />
+        <hr style="clear:both">
 
         <?php echo $this->partial('layout/footer'); ?>
 

--- a/module/Application/view/layout/layout-small-header.phtml
+++ b/module/Application/view/layout/layout-small-header.phtml
@@ -17,35 +17,38 @@
         <?php echo $this->headLink(); ?>
     </head>
     <body>
-        <a href="https://github.com/zendframework/modules.zendframework.com"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub"></a>
-
+        <a href="https://github.com/zendframework/modules.zendframework.com">
+            <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub">
+        </a>
         <div id="toppanel">
             <div class="tab">
                 <ul class="login">
                     <li class="left">&nbsp;</li>
-                    <li><a href="<?php echo $this->url('home'); ?>">Home</a></li>
-                    <?php $userDisplayName = $this->zfcUserDisplayName(); ?>
-                    <?php if ($userDisplayName): ?>
-                        <li class="sep">|</li>
-                        <li class="user-info">
-                            <?php /* @var User\Entity\User $identity */ ?>
-                            <?php $identity = $this->zfcUserIdentity(); ?>
-                            <div class="gravatar-container"><a class="login" href="<?php
-                                echo $this->url('zfcuser');
-                                ?>" title="My profile">
-                                    <img src="<?php
-                                    echo $this->escapeHtmlAttr($identity->getPhotoUrl());
-                                    ?>" alt="<?php echo $this->escapeHtmlAttr($this->zfcUserDisplayName());
-                                    ?>" style="width:23px;height:23px;" />
-                                </a></div><a class="login" href="<?php echo $this->url('zfcuser') ?>" title="My profile"> Hello <?php echo $this->escapeHtml(ucfirst($userDisplayName)); ?></a>
-                        </li>
-                        <li class="sep">|</li>
-                        <li ><a href="<?php echo $this->url('zfcuser/logout'); ?>">Logout</a></li>
-                    <?php else: ?>
-                        <li id="toggle">
-                            <a class="login" href="<?php echo $this->url('scn-social-auth-user/login/provider', ['provider' => 'github']); ?>">GitHub Login</a>
-                        </li>
-                    <?php endif; ?>
+                    <li>
+                        <a href="<?php echo $this->url('home'); ?>">Home</a>
+                    </li>
+                <?php $userDisplayName = $this->zfcUserDisplayName(); ?>
+                <?php if ($userDisplayName): ?>
+                    <li class="sep">|</li>
+                    <li class="user-info">
+                        <?php /* @var User\Entity\User $identity */ ?>
+                        <?php $identity = $this->zfcUserIdentity(); ?>
+                        <div class="gravatar-container">
+                            <a class="login" href="<?php echo $this->url('zfcuser'); ?>" title="My profile">
+                                <img src="<?php echo $this->escapeHtmlAttr($identity->getPhotoUrl()); ?>" alt="<?php echo $this->escapeHtmlAttr($this->zfcUserDisplayName()); ?>" style="width:23px;height:23px;" />
+                            </a>
+                        </div>
+                        <a class="login" href="<?php echo $this->url('zfcuser'); ?>" title="My profile"> Hello <?php echo $this->escapeHtml(ucfirst($userDisplayName)); ?></a>
+                    </li>
+                    <li class="sep">|</li>
+                    <li>
+                        <a href="<?php echo $this->url('zfcuser/logout'); ?>">Logout</a>
+                    </li>
+                <?php else: ?>
+                    <li id="toggle">
+                        <a class="login" href="<?php echo $this->url('scn-social-auth-user/login/provider', ['provider' => 'github']); ?>">GitHub Login</a>
+                    </li>
+                <?php endif; ?>
                     <li class="right">&nbsp;</li>
                 </ul>
             </div>
@@ -57,22 +60,22 @@
                     <div class="col-md-8">
                         <a href="<?php echo $this->url('home'); ?>" style="text-decoration:none">
                             <img src="<?php echo $this->basePath('/img/zend-logo_small.png'); ?>" alt="ZF Modules"/>
-                            <p class="zf-green">Modules</p>
+                            <p class="zf-green">
+                                Modules
+                            </p>
                         </a>
                     </div>
-                    <div class="col-md-4">
-
-                    </div>
+                    <div class="col-md-4"></div>
                 </div>
             </div>
         </div>
 
-
         <div class="container main-content">
             <div class="container-fluid">
                 <?php echo $this->content; ?>
-            </div
+            </div>
         </div>
+
         <hr style="clear:both" />
 
         <?php echo $this->partial('layout/footer'); ?>

--- a/module/Application/view/layout/layout-small-header.phtml
+++ b/module/Application/view/layout/layout-small-header.phtml
@@ -24,9 +24,8 @@
                 <ul class="login">
                     <li class="left">&nbsp;</li>
                     <li><a href="<?php echo $this->url('home'); ?>">Home</a></li>
-                    <?php
-                    $userDisplayName = $this->zfcUserDisplayName();
-                    if ($userDisplayName): ?>
+                    <?php $userDisplayName = $this->zfcUserDisplayName(); ?>
+                    <?php if ($userDisplayName): ?>
                         <li class="sep">|</li>
                         <li class="user-info">
                             <?php /* @var User\Entity\User $identity */ ?>

--- a/module/Application/view/layout/layout-small-header.phtml
+++ b/module/Application/view/layout/layout-small-header.phtml
@@ -2,21 +2,19 @@
 
 <html lang="en">
     <head>
-        <?php echo $this->headTitle('ZF2 Modules')->setSeparator(' - ')->setAutoEscape(false) ?>
+        <?php $this->headTitle('ZF2 Modules')->setSeparator(' - ')->setAutoEscape(false); ?>
+        <?php echo $this->headTitle(); ?>
 
-        <?php
-        echo $this->headMeta()
-                ->appendName('viewport', 'width=device-width, initial-scale=1.0')
-                ->setCharset('UTF-8')
-        ?>
+        <?php $this->headMeta()->appendName('viewport', 'width=device-width, initial-scale=1.0'); ?>
+        <?php $this->headMeta()->setCharset('UTF-8'); ?>
+        <?php echo $this->headMeta(); ?>
 
-        <?php
-        echo $this->headLink(['rel' => 'shortcut icon', 'href' => $this->basePath() . '/favicon.ico'])
-                ->appendStylesheet($this->basePath() . '/css/bootstrap.min.css')
-                ->appendStylesheet($this->basePath() . '/css/style.css')
-                ->appendStylesheet($this->basePath() . '/css/slide.css')
-                ->appendAlternate($this->url('feed'), 'application/rss+xml', 'RSS Feed for ZF2 Modules')
-        ?>
+        <?php $this->headLink(['rel' => 'shortcut icon', 'href' => $this->basePath() . '/favicon.ico']); ?>
+        <?php $this->headLink()->appendStylesheet($this->basePath() . '/css/bootstrap.min.css'); ?>
+        <?php $this->headLink()->appendStylesheet($this->basePath() . '/css/style.css'); ?>
+        <?php $this->headLink()->appendStylesheet($this->basePath() . '/css/slide.css'); ?>
+        <?php $this->headLink()->appendAlternate($this->url('feed'), 'application/rss+xml', 'RSS Feed for ZF2 Modules'); ?>
+        <?php echo $this->headLink(); ?>
     </head>
     <body>
         <a href="https://github.com/zendframework/modules.zendframework.com"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub"></a>
@@ -80,10 +78,8 @@
 
         <?php echo $this->partial('layout/footer'); ?>
 
-        <?php
-        echo $this->inlineScript()
-                ->prependFile($this->basePath() . '/js/bootstrap.min.js')
-                ->prependFile($this->basePath() . '/js/jquery-1.11.2.min.js')
-        ?>
+        <?php $this->inlineScript()->prependFile($this->basePath() . '/js/bootstrap.min.js'); ?>
+        <?php $this->inlineScript()->prependFile($this->basePath() . '/js/jquery-1.11.2.min.js'); ?>
+        <?php echo $this->inlineScript(); ?>
     </body>
 </html>

--- a/module/Application/view/layout/layout-small-header.phtml
+++ b/module/Application/view/layout/layout-small-header.phtml
@@ -65,7 +65,6 @@
                             </p>
                         </a>
                     </div>
-                    <div class="col-md-4"></div>
                 </div>
             </div>
         </div>

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -84,7 +84,7 @@
         <div class="container main-content">
             <div class="container-fluid">
                 <?php echo $this->content; ?>
-            </div
+            </div>
         </div>
 
         <hr style="clear:both" />

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -2,23 +2,20 @@
 
 <html lang="en">
     <head>
-        <?php echo $this->headTitle('ZF2 Modules')->setSeparator(' - ')->setAutoEscape(false) ?>
+        <?php $this->headTitle('ZF2 Modules')->setSeparator(' - ')->setAutoEscape(false); ?>
+        <?php echo $this->headTitle(); ?>
 
-        <?php
-        echo $this->headMeta()
-                ->appendName('viewport', 'width=device-width, initial-scale=1.0')
-                ->setCharset('UTF-8')
-        ?>
+        <?php $this->headMeta()->appendName('viewport', 'width=device-width, initial-scale=1.0'); ?>
+        <?php $this->headMeta()->setCharset('UTF-8'); ?>
+        <?php echo $this->headMeta(); ?>
 
-        <?php
-        echo $this->headLink(['rel' => 'shortcut icon', 'href' => $this->basePath() . '/favicon.ico'])
-                ->appendStylesheet($this->basePath() . '/css/bootstrap.min.css')
-                ->appendStylesheet($this->basePath() . '/css/style.css')
-                ->appendStylesheet($this->basePath() . '/css/slide.css')
-                ->appendStylesheet($this->basePath() . '/css/jquery.livesearch.css')
-                ->appendAlternate($this->url('feed'), 'application/rss+xml', 'RSS Feed for ZF2 Modules')
-        ?>
-
+        <?php $this->headLink(['rel' => 'shortcut icon', 'href' => $this->basePath() . '/favicon.ico']); ?>
+        <?php $this->headLink()->appendStylesheet($this->basePath() . '/css/bootstrap.min.css'); ?>
+        <?php $this->headLink()->appendStylesheet($this->basePath() . '/css/style.css'); ?>
+        <?php $this->headLink()->appendStylesheet($this->basePath() . '/css/slide.css'); ?>
+        <?php $this->headLink()->appendStylesheet($this->basePath() . '/css/jquery.livesearch.css'); ?>
+        <?php $this->headLink()->appendAlternate($this->url('feed'), 'application/rss+xml', 'RSS Feed for ZF2 Modules'); ?>
+        <?php echo $this->headLink(); ?>
     </head>
     <body>
         <a href="https://github.com/zendframework/modules.zendframework.com"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub"></a>
@@ -91,11 +88,9 @@
 
         <?php echo $this->partial('layout/footer'); ?>
 
-        <?php
-        echo $this->inlineScript()
-                ->prependFile($this->basePath() . '/js/jquery.livesearch.js')
-                ->prependFile($this->basePath() . '/js/bootstrap.min.js')
-                ->prependFile($this->basePath() . '/js/jquery-1.11.2.min.js')
-        ?>
+        <?php $this->inlineScript()->prependFile($this->basePath() . '/js/jquery.livesearch.js'); ?>
+        <?php $this->inlineScript()->prependFile($this->basePath() . '/js/bootstrap.min.js'); ?>
+        <?php $this->inlineScript()->prependFile($this->basePath() . '/js/jquery-1.11.2.min.js'); ?>
+        <?php echo $this->inlineScript(); ?>
     </body>
 </html>

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -69,7 +69,6 @@
                                 to browse, search, rate, and comment on all of the great modules the Zend Framework
                                 community has to offer.
                             </p>
-                            <hr>
                             <p>
                                 If you are interested in helping with this project, simply fork the code on
                                 <a class="zf-green" href="https://github.com/zendframework/modules.zendframework.com">GITHUB</a>

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -65,11 +65,6 @@
                         <h3 class="text-muted">Find one of <strong><?php echo $this->totalModules(); ?></strong> modules that fits your needs.</h3>
                         <div>
                             <p>
-                                This website is a work-in-progress. In the future you will be able to use this website
-                                to browse, search, rate, and comment on all of the great modules the Zend Framework
-                                community has to offer.
-                            </p>
-                            <p>
                                 If you are interested in helping with this project, simply fork the code on
                                 <a class="zf-green" href="https://github.com/zendframework/modules.zendframework.com" target="_blank">GitHub</a>
                                 and get started!

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -36,7 +36,7 @@
                         <?php $identity = $this->zfcUserIdentity(); ?>
                         <div class="gravatar-container">
                             <a class="login" href="<?php echo $this->url('zfcuser'); ?>" title="My profile">
-                                <img src="<?php echo $this->escapeHtmlAttr($identity->getPhotoUrl()); ?>" alt="<?php echo $this->escapeHtmlAttr($this->zfcUserDisplayName()); ?>" style="width:23px;height:23px;" />
+                                <img src="<?php echo $this->escapeHtmlAttr($identity->getPhotoUrl()); ?>" alt="<?php echo $this->escapeHtmlAttr($this->zfcUserDisplayName()); ?>" style="width:23px;height:23px;">
                             </a>
                         </div>
                         <a class="login" href="<?php echo $this->url('zfcuser'); ?>" title="My profile"> Hello <?php echo $this->escapeHtml(ucfirst($userDisplayName)); ?></a>
@@ -67,7 +67,7 @@
                             <p>
                                 This website is a work-in-progress. In the future you will be able to use this website to   browse, search, rate, and comment on all of the great modules the Zend Framework community has to offer.
                             </p>
-                            <hr />
+                            <hr>
                             <p>
                                 If you are interested in helping with this project, simply fork the code on <a class="zf-green" href="https://github.com/zendframework/modules.zendframework.com">GITHUB</a> and get started!
                                 Additionally, join us in #zftalk.modules on Freenode and ask how you can help! Grab latest modules using <a class="zf-green" href="<?php echo $this->url('feed') ?>">RSS Feed</a>.
@@ -75,7 +75,7 @@
                         </div>
                     </div>
                     <div class="col-md-4 hidden-xs hidden-sm">
-                        <img class="attentionimage pull-right" src="<?php echo $this->basePath('/img/rsz_logo.png'); ?>" alt="ZF Modules"/>
+                        <img class="attentionimage pull-right" src="<?php echo $this->basePath('/img/rsz_logo.png'); ?>" alt="ZF Modules">
                     </div>
                 </div>
             </div>
@@ -87,7 +87,7 @@
             </div>
         </div>
 
-        <hr style="clear:both" />
+        <hr style="clear:both">
 
         <?php echo $this->partial('layout/footer'); ?>
 

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -25,10 +25,8 @@
                 <ul class="login">
                     <li class="left">&nbsp;</li>
                     <li><a href="<?php echo $this->url('home') ?>">Home</a></li>
-                    <?php
-                    $userDisplayName = $this->zfcUserDisplayName();
-                    if ($userDisplayName):
-                        ?>
+                    <?php $userDisplayName = $this->zfcUserDisplayName(); ?>
+                    <?php if ($userDisplayName): ?>
                         <li class="sep">|</li>
                         <li class="user-info">
                             <?php /* @var User\Entity\User $identity */ ?>

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -65,12 +65,17 @@
                         <h3 class="text-muted">Find one of <strong><?php echo $this->totalModules(); ?></strong> modules that fits your needs.</h3>
                         <div>
                             <p>
-                                This website is a work-in-progress. In the future you will be able to use this website to   browse, search, rate, and comment on all of the great modules the Zend Framework community has to offer.
+                                This website is a work-in-progress. In the future you will be able to use this website
+                                to browse, search, rate, and comment on all of the great modules the Zend Framework
+                                community has to offer.
                             </p>
                             <hr>
                             <p>
-                                If you are interested in helping with this project, simply fork the code on <a class="zf-green" href="https://github.com/zendframework/modules.zendframework.com">GITHUB</a> and get started!
-                                Additionally, join us in #zftalk.modules on Freenode and ask how you can help! Grab latest modules using <a class="zf-green" href="<?php echo $this->url('feed') ?>">RSS Feed</a>.
+                                If you are interested in helping with this project, simply fork the code on
+                                <a class="zf-green" href="https://github.com/zendframework/modules.zendframework.com">GITHUB</a>
+                                and get started!
+                                Additionally, join us in #zftalk.modules on Freenode and ask how you can help!
+                                Grab latest modules using <a class="zf-green" href="<?php echo $this->url('feed') ?>">RSS Feed</a>.
                             </p>
                         </div>
                     </div>

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -18,33 +18,38 @@
         <?php echo $this->headLink(); ?>
     </head>
     <body>
-        <a href="https://github.com/zendframework/modules.zendframework.com"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub"></a>
-
+        <a href="https://github.com/zendframework/modules.zendframework.com">
+            <img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_green_007200.png" alt="Fork me on GitHub">
+        </a>
         <div id="toppanel">
             <div class="tab">
                 <ul class="login">
                     <li class="left">&nbsp;</li>
-                    <li><a href="<?php echo $this->url('home') ?>">Home</a></li>
-                    <?php $userDisplayName = $this->zfcUserDisplayName(); ?>
-                    <?php if ($userDisplayName): ?>
-                        <li class="sep">|</li>
-                        <li class="user-info">
-                            <?php /* @var User\Entity\User $identity */ ?>
-                            <?php $identity = $this->zfcUserIdentity(); ?>
-                            <div class="gravatar-container"><a class="login" href="<?php echo $this->url('zfcuser') ?>" title="My profile">
-                                    <img src="<?php
-                                    echo $this->escapeHtmlAttr($identity->getPhotoUrl());
-                                    ?>" alt="<?php echo $this->escapeHtmlAttr($this->zfcUserDisplayName());
-                                    ?>" style="width:23px;height:23px;" />
-                                </a></div><a class="login" href="<?php echo $this->url('zfcuser') ?>" title="My profile"> Hello <?php echo $this->escapeHtml(ucfirst($userDisplayName)) ?></a>
-                        </li>
-                        <li class="sep">|</li>
-                        <li ><a href="<?php echo $this->url('zfcuser/logout') ?>">Logout</a></li>
-                    <?php else: ?>
-                        <li id="toggle">
-                            <a class="login" href="<?php echo $this->url('scn-social-auth-user/login/provider', ['provider' => 'github']) ?>">GitHub Login</a>
-                        </li>
-                    <?php endif; ?>
+                    <li>
+                        <a href="<?php echo $this->url('home'); ?>">Home</a>
+                    </li>
+                <?php $userDisplayName = $this->zfcUserDisplayName(); ?>
+                <?php if ($userDisplayName): ?>
+                    <li class="sep">|</li>
+                    <li class="user-info">
+                        <?php /* @var User\Entity\User $identity */ ?>
+                        <?php $identity = $this->zfcUserIdentity(); ?>
+                        <div class="gravatar-container">
+                            <a class="login" href="<?php echo $this->url('zfcuser'); ?>" title="My profile">
+                                <img src="<?php echo $this->escapeHtmlAttr($identity->getPhotoUrl()); ?>" alt="<?php echo $this->escapeHtmlAttr($this->zfcUserDisplayName()); ?>" style="width:23px;height:23px;" />
+                            </a>
+                        </div>
+                        <a class="login" href="<?php echo $this->url('zfcuser'); ?>" title="My profile"> Hello <?php echo $this->escapeHtml(ucfirst($userDisplayName)); ?></a>
+                    </li>
+                    <li class="sep">|</li>
+                    <li>
+                        <a href="<?php echo $this->url('zfcuser/logout'); ?>">Logout</a>
+                    </li>
+                <?php else: ?>
+                    <li id="toggle">
+                        <a class="login" href="<?php echo $this->url('scn-social-auth-user/login/provider', ['provider' => 'github']); ?>">GitHub Login</a>
+                    </li>
+                <?php endif; ?>
                     <li class="right">&nbsp;</li>
                 </ul>
             </div>
@@ -57,7 +62,7 @@
                         <h1 class="zf-green">
                             <strong>Welcome to the ZF2 Modules Site</strong>
                         </h1>
-                        <h3 class="text-muted">Find one of <strong><?php echo $this->totalModules() ?></strong> modules that fits your needs.</h3>
+                        <h3 class="text-muted">Find one of <strong><?php echo $this->totalModules(); ?></strong> modules that fits your needs.</h3>
                         <div>
                             <p>
                                 This website is a work-in-progress. In the future you will be able to use this website to   browse, search, rate, and comment on all of the great modules the Zend Framework community has to offer.
@@ -70,18 +75,18 @@
                         </div>
                     </div>
                     <div class="col-md-4 hidden-xs hidden-sm">
-                        <img class="attentionimage pull-right" src="<?php echo $this->basePath('/img/rsz_logo.png') ?>" alt="ZF Modules"/>
+                        <img class="attentionimage pull-right" src="<?php echo $this->basePath('/img/rsz_logo.png'); ?>" alt="ZF Modules"/>
                     </div>
                 </div>
             </div>
         </div>
 
-
         <div class="container main-content">
             <div class="container-fluid">
                 <?php echo $this->content; ?>
-            </div>
+            </div
         </div>
+
         <hr style="clear:both" />
 
         <?php echo $this->partial('layout/footer'); ?>

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -73,7 +73,11 @@
                                 If you are interested in helping with this project, simply fork the code on
                                 <a class="zf-green" href="https://github.com/zendframework/modules.zendframework.com">GITHUB</a>
                                 and get started!
+                            </p>
+                            <p>
                                 Additionally, join us in #zftalk.modules on Freenode and ask how you can help!
+                            </p>
+                            <p>
                                 Grab latest modules using <a class="zf-green" href="<?php echo $this->url('feed') ?>">RSS Feed</a>.
                             </p>
                         </div>

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -71,7 +71,7 @@
                             </p>
                             <p>
                                 If you are interested in helping with this project, simply fork the code on
-                                <a class="zf-green" href="https://github.com/zendframework/modules.zendframework.com">GITHUB</a>
+                                <a class="zf-green" href="https://github.com/zendframework/modules.zendframework.com" target="_blank">GitHub</a>
                                 and get started!
                             </p>
                             <p>


### PR DESCRIPTION
The aim of this PR is to streamline the existing layouts in order to reduce duplication, so we can move on and actually change it without having to do in two places.

* [x] splits setting up and rendering view helpers
* [x] fixes some alternative syntax blocks spanning multiple lines
* [x] fixes wrapping, indentation, adds missing trailing semicolons (for consistency)
* [x] fixes a closing tag that isn't one
* [x] uses HTML5 style for self-enclosing tags
* [x] removes text that states the obvious
* [x] splits text into paragraphs

### Before

![screen shot 2015-02-18 at 17 31 11](https://cloud.githubusercontent.com/assets/605483/6251403/1286916c-b794-11e4-9120-4d2e87b211c0.png)

### After

![screen shot 2015-02-18 at 17 30 52](https://cloud.githubusercontent.com/assets/605483/6251416/201e461c-b794-11e4-8635-5277aaec2665.png)
