### PR TITLE
Enhancement: Use small header layout in User module

### DIFF
--- a/config/autoload/global.php
+++ b/config/autoload/global.php
@@ -1,6 +1,7 @@
 <?php
 return [
     'module_layouts' => [
+        'User' => 'layout/layout-small-header.phtml',
         'ZfcUser' => 'layout/layout-small-header.phtml',
         'ZfModule' => 'layout/layout-small-header.phtml',
     ],


### PR DESCRIPTION
This PR

* [x] configures the `User` module to use the layout with the small header, leaving more actual room on the page

See http://modules.zendframework.com/user

### Before

![screen shot 2015-02-18 at 19 39 42](https://cloud.githubusercontent.com/assets/605483/6254083/2d84de4e-b7a6-11e4-8c51-24c6bd53ce7d.png)

### After

![screen shot 2015-02-18 at 19 39 57](https://cloud.githubusercontent.com/assets/605483/6254092/41fa8432-b7a6-11e4-8566-0a682d5a1e46.png)


