### PR TITLE
Fix: Only load live-search resources when needed

### DIFF
--- a/module/Application/view/application/index/index.phtml
+++ b/module/Application/view/application/index/index.phtml
@@ -1,6 +1,6 @@
 <?php $this->headTitle(sprintf('Browse %d modules for Zend Framework 2', $this->totalModules())); ?>
 <?php $this->headLink()->appendStylesheet($this->basePath('css/jquery.livesearch.css')); ?>
-<?php $this->inlineScript()->prependFile($this->basePath('js/jquery.livesearch.js')); ?>
+<?php $this->inlineScript()->appendFile($this->basePath('js/jquery.livesearch.js')); ?>
 <?php $this->inlineScript()->appendScript('$(\'#live-search input[name="query"]\').liveSearch({url: "' . $this->url('live-search', [], ['query' => ['query' => '']]) . '"});'); ?>
 
 <div class="col-xs-12 col-md-8">

--- a/module/Application/view/application/index/index.phtml
+++ b/module/Application/view/application/index/index.phtml
@@ -1,4 +1,6 @@
 <?php $this->headTitle(sprintf('Browse %d modules for Zend Framework 2', $this->totalModules())); ?>
+<?php $this->headLink()->appendStylesheet($this->basePath('css/jquery.livesearch.css')); ?>
+<?php $this->inlineScript()->prependFile($this->basePath('js/jquery.livesearch.js')); ?>
 <?php $this->inlineScript()->appendScript('$(\'#live-search input[name="query"]\').liveSearch({url: "' . $this->url('live-search', [], ['query' => ['query' => '']]) . '"});'); ?>
 
 <div class="col-xs-12 col-md-8">

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -13,7 +13,6 @@
         <?php $this->headLink()->appendStylesheet($this->basePath('css/bootstrap.min.css')); ?>
         <?php $this->headLink()->appendStylesheet($this->basePath('css/style.css')); ?>
         <?php $this->headLink()->appendStylesheet($this->basePath('css/slide.css')); ?>
-        <?php $this->headLink()->appendStylesheet($this->basePath('css/jquery.livesearch.css')); ?>
         <?php $this->headLink()->appendAlternate($this->url('feed'), 'application/rss+xml', 'RSS Feed for ZF2 Modules'); ?>
         <?php echo $this->headLink(); ?>
     </head>
@@ -94,7 +93,6 @@
 
         <?php echo $this->partial('layout/footer'); ?>
 
-        <?php $this->inlineScript()->prependFile($this->basePath('js/jquery.livesearch.js')); ?>
         <?php $this->inlineScript()->prependFile($this->basePath('js/bootstrap.min.js')); ?>
         <?php $this->inlineScript()->prependFile($this->basePath('js/jquery-1.11.2.min.js')); ?>
         <?php echo $this->inlineScript(); ?>


### PR DESCRIPTION
This PR

* [x] moves loading of resources related to live-search to the only place where they are actually needed, which is, the corresponding view script

:bulb: The aim of this PR is to make the diff between `layout/layout.phtml` and `layout/layout-small-header.phtml` smaller, in order to eventually get rid of a lot of duplication.

Follows #397.