### PR TITLE
Fix: BasePath helper accepts argument, prepends with /

### DIFF
--- a/module/Application/view/layout/layout-small-header.phtml
+++ b/module/Application/view/layout/layout-small-header.phtml
@@ -9,10 +9,10 @@
         <?php $this->headMeta()->setCharset('UTF-8'); ?>
         <?php echo $this->headMeta(); ?>
 
-        <?php $this->headLink(['rel' => 'shortcut icon', 'href' => $this->basePath() . '/favicon.ico']); ?>
-        <?php $this->headLink()->appendStylesheet($this->basePath() . '/css/bootstrap.min.css'); ?>
-        <?php $this->headLink()->appendStylesheet($this->basePath() . '/css/style.css'); ?>
-        <?php $this->headLink()->appendStylesheet($this->basePath() . '/css/slide.css'); ?>
+        <?php $this->headLink(['rel' => 'shortcut icon', 'href' => $this->basePath('favicon.ico')]); ?>
+        <?php $this->headLink()->appendStylesheet($this->basePath('css/bootstrap.min.css')); ?>
+        <?php $this->headLink()->appendStylesheet($this->basePath('css/style.css')); ?>
+        <?php $this->headLink()->appendStylesheet($this->basePath('css/slide.css')); ?>
         <?php $this->headLink()->appendAlternate($this->url('feed'), 'application/rss+xml', 'RSS Feed for ZF2 Modules'); ?>
         <?php echo $this->headLink(); ?>
     </head>
@@ -59,7 +59,7 @@
                 <div class="row">
                     <div class="col-md-8">
                         <a href="<?php echo $this->url('home'); ?>" style="text-decoration:none">
-                            <img src="<?php echo $this->basePath('/img/zend-logo_small.png'); ?>" alt="ZF Modules">
+                            <img src="<?php echo $this->basePath('img/zend-logo_small.png'); ?>" alt="ZF Modules">
                             <p class="zf-green">
                                 Modules
                             </p>
@@ -79,8 +79,8 @@
 
         <?php echo $this->partial('layout/footer'); ?>
 
-        <?php $this->inlineScript()->prependFile($this->basePath() . '/js/bootstrap.min.js'); ?>
-        <?php $this->inlineScript()->prependFile($this->basePath() . '/js/jquery-1.11.2.min.js'); ?>
+        <?php $this->inlineScript()->prependFile($this->basePath('js/bootstrap.min.js')); ?>
+        <?php $this->inlineScript()->prependFile($this->basePath('js/jquery-1.11.2.min.js')); ?>
         <?php echo $this->inlineScript(); ?>
     </body>
 </html>

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -9,11 +9,11 @@
         <?php $this->headMeta()->setCharset('UTF-8'); ?>
         <?php echo $this->headMeta(); ?>
 
-        <?php $this->headLink(['rel' => 'shortcut icon', 'href' => $this->basePath() . '/favicon.ico']); ?>
-        <?php $this->headLink()->appendStylesheet($this->basePath() . '/css/bootstrap.min.css'); ?>
-        <?php $this->headLink()->appendStylesheet($this->basePath() . '/css/style.css'); ?>
-        <?php $this->headLink()->appendStylesheet($this->basePath() . '/css/slide.css'); ?>
-        <?php $this->headLink()->appendStylesheet($this->basePath() . '/css/jquery.livesearch.css'); ?>
+        <?php $this->headLink(['rel' => 'shortcut icon', 'href' => $this->basePath('favicon.ico')]); ?>
+        <?php $this->headLink()->appendStylesheet($this->basePath('css/bootstrap.min.css')); ?>
+        <?php $this->headLink()->appendStylesheet($this->basePath('css/style.css')); ?>
+        <?php $this->headLink()->appendStylesheet($this->basePath('css/slide.css')); ?>
+        <?php $this->headLink()->appendStylesheet($this->basePath('css/jquery.livesearch.css')); ?>
         <?php $this->headLink()->appendAlternate($this->url('feed'), 'application/rss+xml', 'RSS Feed for ZF2 Modules'); ?>
         <?php echo $this->headLink(); ?>
     </head>
@@ -78,7 +78,7 @@
                         </div>
                     </div>
                     <div class="col-md-4 hidden-xs hidden-sm">
-                        <img class="attentionimage pull-right" src="<?php echo $this->basePath('/img/rsz_logo.png'); ?>" alt="ZF Modules">
+                        <img class="attentionimage pull-right" src="<?php echo $this->basePath('img/rsz_logo.png'); ?>" alt="ZF Modules">
                     </div>
                 </div>
             </div>
@@ -94,9 +94,9 @@
 
         <?php echo $this->partial('layout/footer'); ?>
 
-        <?php $this->inlineScript()->prependFile($this->basePath() . '/js/jquery.livesearch.js'); ?>
-        <?php $this->inlineScript()->prependFile($this->basePath() . '/js/bootstrap.min.js'); ?>
-        <?php $this->inlineScript()->prependFile($this->basePath() . '/js/jquery-1.11.2.min.js'); ?>
+        <?php $this->inlineScript()->prependFile($this->basePath('js/jquery.livesearch.js')); ?>
+        <?php $this->inlineScript()->prependFile($this->basePath('js/bootstrap.min.js')); ?>
+        <?php $this->inlineScript()->prependFile($this->basePath('js/jquery-1.11.2.min.js')); ?>
         <?php echo $this->inlineScript(); ?>
     </body>
 </html>

--- a/module/User/view/user/helper/user-organizations.phtml
+++ b/module/User/view/user/helper/user-organizations.phtml
@@ -19,7 +19,7 @@
         <div class="row accordion-body collapse" id="org-<?php echo $this->escapeHtmlAttr($org->login) ?>">
             <div class="module-description">
                 <div class="col-md-12" id="org-content-<?php echo $this->escapeHtmlAttr($org->login) ?>">
-                    <div class="well" style="text-align:center">Synchronizing with GitHub <img src="<?php echo $this->basePath('/img/ajax-loader.gif') ?>" alt="loading" /></div>
+                    <div class="well" style="text-align:center">Synchronizing with GitHub <img src="<?php echo $this->basePath('img/ajax-loader.gif') ?>" alt="loading" /></div>
                 </div>
             </div>
         </div>

--- a/module/User/view/zfc-user/user/index.phtml
+++ b/module/User/view/zfc-user/user/index.phtml
@@ -32,7 +32,7 @@
             <?php endif; ?>
             </div>
             <div class="tab-pane" id="repositories">
-                <div class="well" style="text-align:center">Synchronizing with GitHub <img src="<?php echo $this->basePath('/img/ajax-loader.gif'); ?>" alt="loading" /></div>
+                <div class="well" style="text-align:center">Synchronizing with GitHub <img src="<?php echo $this->basePath('img/ajax-loader.gif'); ?>" alt="loading" /></div>
             </div>
 
             <div class="tab-pane" id="organizations">


### PR DESCRIPTION
This PR

* [x] makes use of the fact that the `BasePath` view helper actually accepts an argument, the name of the file to be prepended with the actual base path

Follows f1694ca.