### PR TITLE
Fix: Semantic markup for GitHub ribbon

### DIFF
--- a/module/Application/public/css/style.css
+++ b/module/Application/public/css/style.css
@@ -181,3 +181,14 @@ div.container a.brand {
 
     background: url(../img/speech-bubble-arrow.png) no-repeat;
 }
+
+/* Revisited Styles */
+
+.fork-me-ribbon {
+    position: absolute;
+    top: 0;
+    right: 0;
+    border: 0;
+    width: 149px;
+    height: 149px;
+}

--- a/module/Application/public/css/style.css
+++ b/module/Application/public/css/style.css
@@ -184,11 +184,16 @@ div.container a.brand {
 
 /* Revisited Styles */
 
-.fork-me-ribbon {
+.fork-me-ribbon a {
     position: absolute;
     top: 0;
     right: 0;
     border: 0;
     width: 149px;
     height: 149px;
+    background-image: url(../img/aral/github-ribbons/right-green@2x.png);
+    background-size: 149px 149px;
+    text-indent: 100%;
+    white-space: nowrap;
+    overflow: hidden;
 }

--- a/module/Application/public/css/style.css
+++ b/module/Application/public/css/style.css
@@ -186,7 +186,7 @@ div.container a.brand {
 
 .fork-me-ribbon a {
     position: absolute;
-    top: 0;
+    top: 7px;
     right: 0;
     border: 0;
     width: 149px;

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -11,14 +11,14 @@
 
         <?php $this->headLink(['rel' => 'shortcut icon', 'href' => $this->basePath('favicon.ico')]); ?>
         <?php $this->headLink()->appendStylesheet($this->basePath('css/bootstrap.min.css')); ?>
-        <?php $this->headLink()->appendStylesheet($this->basePath('css/style.css')); ?>
+        <?php $this->headLink()->appendStylesheet($this->basePath('css/style.css?201502201415')); ?>
         <?php $this->headLink()->appendStylesheet($this->basePath('css/slide.css')); ?>
         <?php $this->headLink()->appendAlternate($this->url('feed'), 'application/rss+xml', 'RSS Feed for ZF2 Modules'); ?>
         <?php echo $this->headLink(); ?>
     </head>
     <body>
         <a href="https://github.com/zendframework/modules.zendframework.com" target="_blank">
-            <img style="position: absolute; top: 0; right: 0; border: 0; width: 149px; height: 149px;" src="<?php echo $this->basePath('img/aral/github-ribbons/right-green@2x.png'); ?>" alt="Fork me on GitHub">
+            <img class="fork-me-ribbon" src="<?php echo $this->basePath('img/aral/github-ribbons/right-green@2x.png'); ?>" alt="Fork me on GitHub">
         </a>
         <div id="toppanel">
             <div class="tab">

--- a/module/Application/view/layout/layout.phtml
+++ b/module/Application/view/layout/layout.phtml
@@ -17,9 +17,9 @@
         <?php echo $this->headLink(); ?>
     </head>
     <body>
-        <a href="https://github.com/zendframework/modules.zendframework.com" target="_blank">
-            <img class="fork-me-ribbon" src="<?php echo $this->basePath('img/aral/github-ribbons/right-green@2x.png'); ?>" alt="Fork me on GitHub">
-        </a>
+        <aside class="fork-me-ribbon">
+            <a href="https://github.com/zendframework/modules.zendframework.com" target="_blank">Fork me on GitHub</a>
+        </aside>
         <div id="toppanel">
             <div class="tab">
                 <ul class="login">


### PR DESCRIPTION
This PR

* [x] extracts a class `fork-me-ribbon` from the inline-styles attached to the GitHub ribbon image
* [x] increases the semanticity (is that even a word?) of the markup be wrapping the link in an `<aside>` then removing the image from the markup and specifiying it as a background image (see http://zeldman.com/2012/03/01/replacing-the-9999px-hack-new-image-replacement/)* 
* [x] moves the ribbon a bit down, as it's currently underneath the sliding login panel thingy

### Before

![screen shot 2015-02-20 at 14 32 55](https://cloud.githubusercontent.com/assets/605483/6286950/6986172e-b90d-11e4-94fc-f00348ae8c4b.png)

### After

![screen shot 2015-02-20 at 14 33 05](https://cloud.githubusercontent.com/assets/605483/6286956/6ef527f4-b90d-11e4-8051-845fb79c38ff.png)

Kind of working my way down from the top, as you can see!
