### PR TITLE
Enhancement: Deploy with Phing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 .php_cs.cache
+build.properties
 clover.xml
 .vagrant
 vendor

--- a/build.properties.dist
+++ b/build.properties.dist
@@ -1,0 +1,5 @@
+ssh.user =
+ssh.host =
+ssh.port =
+
+project.root =

--- a/build.xml
+++ b/build.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="modules.zendframework.com" default="main">
+
+    <property file="build.properties" />
+
+    <target hidden="true" name="main">
+        <echo message="Choose your task, please - use 'vendor/bin/phing -l' to see a list of available tasks" />
+    </target>
+
+    <target hidden="true" name="git-pull">
+        <echo message="Pull changes from origin" />
+        <exec logoutput="true" checkreturn="true" command="ssh ${ssh.user}@${ssh.host} -p {ssh.port} 'cd ${project.root}; git pull origin master'" />
+    </target>
+
+    <target hidden="true" name="composer-install">
+        <echo message="Install dependencies with Composer" />
+        <exec logoutput="true" checkreturn="true" command="ssh ${ssh.user}@${ssh.host} -p {ssh.port} 'cd ${project.root}; sudo composer install --no-dev'" />
+    </target>
+
+    <target hidden="true" name="owner-change">
+        <echo message="Changing owner" />
+        <exec logoutput="true" checkreturn="true" command="ssh ${ssh.user}@${ssh.host} -p {ssh.port} 'sudo chown -R www-data:www-data ${project.root}'" />
+    </target>
+
+    <target name="deploy" description="Deploys application to production" depends="git-pull, composer-install, owner-change">
+        <echo message="Successfully deployed to production" />
+    </target>
+</project>

--- a/build.xml
+++ b/build.xml
@@ -19,7 +19,7 @@
 
     <target hidden="true" name="owner-change">
         <echo message="Changing owner" />
-        <exec logoutput="true" checkreturn="true" command="ssh ${ssh.user}@${ssh.host} -p ${ssh.port} 'sudo chown -R www-data:www-data ${project.root}'" />
+        <exec logoutput="true" checkreturn="true" command="ssh ${ssh.user}@${ssh.host} -p ${ssh.port} 'sudo chown -R www-data:www-data ${project.root}/data'" />
     </target>
 
     <target name="deploy" description="Deploys application to production" depends="git-pull, composer-install, owner-change">

--- a/build.xml
+++ b/build.xml
@@ -9,17 +9,17 @@
 
     <target hidden="true" name="git-pull">
         <echo message="Pull changes from origin" />
-        <exec logoutput="true" checkreturn="true" command="ssh ${ssh.user}@${ssh.host} -p {ssh.port} 'cd ${project.root}; git pull origin master'" />
+        <exec logoutput="true" checkreturn="true" command="ssh ${ssh.user}@${ssh.host} -p ${ssh.port} 'cd ${project.root}; git pull origin master'" />
     </target>
 
     <target hidden="true" name="composer-install">
         <echo message="Install dependencies with Composer" />
-        <exec logoutput="true" checkreturn="true" command="ssh ${ssh.user}@${ssh.host} -p {ssh.port} 'cd ${project.root}; sudo composer install --no-dev'" />
+        <exec logoutput="true" checkreturn="true" command="ssh ${ssh.user}@${ssh.host} -p ${ssh.port} 'cd ${project.root}; sudo composer install --no-dev'" />
     </target>
 
     <target hidden="true" name="owner-change">
         <echo message="Changing owner" />
-        <exec logoutput="true" checkreturn="true" command="ssh ${ssh.user}@${ssh.host} -p {ssh.port} 'sudo chown -R www-data:www-data ${project.root}'" />
+        <exec logoutput="true" checkreturn="true" command="ssh ${ssh.user}@${ssh.host} -p ${ssh.port} 'sudo chown -R www-data:www-data ${project.root}'" />
     </target>
 
     <target name="deploy" description="Deploys application to production" depends="git-pull, composer-install, owner-change">

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "ext-intl": "*",
         "ezyang/htmlpurifier": "4.6.*",
         "monolog/monolog": "~1.12",
+        "phing/phing": "~2.10",
         "php": "~5.5",
         "socalnick/scn-social-auth": "1.14.1",
         "zendframework/zendframework": "~2.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "c7a6e03f7ee9c6bc1efb738584d7bfc7",
+    "hash": "63ea636b6c7c4d69f8682e5b8d7cde6e",
     "packages": [
         {
             "name": "evandotpro/edp-github",
@@ -232,6 +232,96 @@
                 "psr-3"
             ],
             "time": "2014-12-29 21:29:35"
+        },
+        {
+            "name": "phing/phing",
+            "version": "2.10.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phingofficial/phing.git",
+                "reference": "f6c25373cbce5e042dddd9b951a3d5638bb78f67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phingofficial/phing/zipball/f6c25373cbce5e042dddd9b951a3d5638bb78f67",
+                "reference": "f6c25373cbce5e042dddd9b951a3d5638bb78f67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2.0"
+            },
+            "require-dev": {
+                "ext-pdo_sqlite": "*",
+                "lastcraft/simpletest": "@dev",
+                "pdepend/pdepend": "2.x",
+                "pear-pear.php.net/http_request2": "2.2.x",
+                "pear-pear.php.net/net_growl": "2.7.x",
+                "pear-pear.php.net/pear_packagefilemanager": "1.7.x",
+                "pear-pear.php.net/pear_packagefilemanager2": "1.0.x",
+                "pear-pear.php.net/xml_serializer": "0.20.x",
+                "pear/pear_exception": "~1.0",
+                "pear/versioncontrol_git": "@dev",
+                "pear/versioncontrol_svn": "~0.5",
+                "phpdocumentor/phpdocumentor": "2.x",
+                "phploc/phploc": "2.x",
+                "phpmd/phpmd": "~2.2",
+                "phpunit/phpunit": ">=3.7",
+                "sebastian/phpcpd": "2.x",
+                "squizlabs/php_codesniffer": "~2.2"
+            },
+            "suggest": {
+                "pdepend/pdepend": "PHP version of JDepend",
+                "pear/archive_tar": "Tar file management class",
+                "pear/versioncontrol_git": "A library that provides OO interface to handle Git repository",
+                "pear/versioncontrol_svn": "A simple OO-style interface for Subversion, the free/open-source version control system",
+                "phpdocumentor/phpdocumentor": "Documentation Generator for PHP",
+                "phploc/phploc": "A tool for quickly measuring the size of a PHP project",
+                "phpmd/phpmd": "PHP version of PMD tool",
+                "phpunit/php-code-coverage": "Library that provides collection, processing, and rendering functionality for PHP code coverage information",
+                "phpunit/phpunit": "The PHP Unit Testing Framework",
+                "sebastian/phpcpd": "Copy/Paste Detector (CPD) for PHP code",
+                "tedivm/jshrink": "Javascript Minifier built in PHP"
+            },
+            "bin": [
+                "bin/phing"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.10.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "classes/phing/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "classes"
+            ],
+            "license": [
+                "LGPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "Phing Community",
+                    "homepage": "http://www.phing.info/trac/wiki/Development/Contributors"
+                },
+                {
+                    "name": "Michiel Rook",
+                    "email": "mrook@php.net"
+                }
+            ],
+            "description": "PHing Is Not GNU make; it's a PHP project build system or build tool based on Apache Ant.",
+            "homepage": "http://www.phing.info/",
+            "keywords": [
+                "build",
+                "phing",
+                "task",
+                "tool"
+            ],
+            "time": "2015-02-19 15:49:46"
         },
         {
             "name": "psr/log",


### PR DESCRIPTION
The aim of this PR is to ease the deployment process and replicate the current process. I believe we could reiterate on this and, as @GeeH suggested, sort out something with rollbacks and the like

This PR, however, 

* [x] requires `phing/phing` as a dependency
* [x] creates a simple build file replicating the current process
