### PR TITLE
Fix: Wrong CSS class for labels

### DIFF
--- a/module/ZfModule/view/zf-module/helper/composer-view.phtml
+++ b/module/ZfModule/view/zf-module/helper/composer-view.phtml
@@ -13,7 +13,7 @@
     <ul>
         <?php foreach ($this->composerConf['require-dev'] as $requireName => $requireVersion): ?>
             <li>
-                <?php echo $this->escapeHtml($requireName) ?>: <span class='label label-important'><?php echo $this->escapeHtml($requireVersion) ?></span>
+                <?php echo $this->escapeHtml($requireName) ?>: <span class='label label-danger'><?php echo $this->escapeHtml($requireVersion) ?></span>
             </li>
         <?php endforeach; ?>
     </ul>


### PR DESCRIPTION
There is no `label-important` CSS class in [Bootstrap 3](http://getbootstrap.com/components/#labels) (was in [Bootstrap 2](http://getbootstrap.com/2.3.2/components.html#labels-badges)). Equivalent class in new version is `label-danger`.

