### PR TITLE
Fix: Return null if nothing was found by Mapper\Module

### DIFF
--- a/module/ZfModule/src/ZfModule/Mapper/Module.php
+++ b/module/ZfModule/src/ZfModule/Mapper/Module.php
@@ -146,7 +146,8 @@ class Module extends AbstractDbMapper implements ModuleInterface
         $select = $this->getSelect();
         $select->where([$key => $value]);
 
-        $entity = $this->select($select)->current();
+        $entity = $this->select($select)->current() ?: null;
+
         $this->getEventManager()->trigger('find', $this, ['entity' => $entity]);
 
         return $entity;

--- a/module/ZfModule/src/ZfModule/Service/Module.php
+++ b/module/ZfModule/src/ZfModule/Service/Module.php
@@ -131,7 +131,7 @@ class Module extends EventProvider
                 return false;
             }
 
-            if (false === $this->moduleMapper->findByUrl($repository->html_url)) {
+            if (null === $this->moduleMapper->findByUrl($repository->html_url)) {
                 return false;
             }
 

--- a/module/ZfModule/src/ZfModule/Service/Module.php
+++ b/module/ZfModule/src/ZfModule/Service/Module.php
@@ -131,7 +131,7 @@ class Module extends EventProvider
                 return false;
             }
 
-            if (null === $this->moduleMapper->findByUrl($repository->html_url)) {
+            if (!$this->moduleMapper->findByUrl($repository->html_url)) {
                 return false;
             }
 

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/IndexControllerTest.php
@@ -927,7 +927,7 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
             ->expects($this->once())
             ->method('findByUrl')
             ->with($this->equalTo($unregisteredModule->html_url))
-            ->willReturn(false)
+            ->willReturn(null)
         ;
 
         $this->getApplicationServiceLocator()

--- a/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Mapper/ModuleTest.php
@@ -94,6 +94,11 @@ class ModuleTest extends PHPUnit_Framework_TestCase
         $this->assertCount(1, $resultSet);
     }
 
+    public function testFindByReturnsNullIfNothingWasFound()
+    {
+        $this->assertNull($this->mapper->findBy('name', 'foo'));
+    }
+
     /**
      * @return array
      */

--- a/module/ZfModule/test/ZfModuleTest/Service/ModuleTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Service/ModuleTest.php
@@ -221,7 +221,7 @@ class ModuleTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('findByUrl')
             ->with($this->equalTo($repository->html_url))
-            ->willReturn(false)
+            ->willReturn(null)
         ;
 
         $currentUserService = $this->getMockBuilder(Api\CurrentUser::class)->getMock();
@@ -381,7 +381,7 @@ class ModuleTest extends PHPUnit_Framework_TestCase
             ->expects($this->once())
             ->method('findByUrl')
             ->with($this->equalTo($repository->html_url))
-            ->willReturn(false)
+            ->willReturn(null)
         ;
 
         $moduleMapper


### PR DESCRIPTION
This PR

* [x] makes sure that `null` is returned instead of `false` if `ZfModule\Mapper\Module` couldn't find a thing

See https://github.com/zendframework/modules.zendframework.com/pull/416/files#r25241195.