### PR TITLE
Fix: Update README in regard to releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,6 @@ To enable development mode:
 ## Deployment
 
 The master branch of this repository is manually deployed live to [modules.zendframework.com](http://modules.zendframework.com/) by [@GeeH](https://github.com/GeeH).
+
+:bulb: After deployment, a tag is created, so the latest of the [releases](https://github.com/zendframework/modules.zendframework.com/releases)
+represents what is deployed to production.


### PR DESCRIPTION
This PR

* [x] updates `README.md` with a note that the latest release always represents actual code deployed to production