### PR TITLE
Fix: Sudo required for pulling in changes on server

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -9,7 +9,7 @@
 
     <target hidden="true" name="git-pull">
         <echo message="Pull changes from origin" />
-        <exec logoutput="true" checkreturn="true" command="ssh ${ssh.user}@${ssh.host} -p ${ssh.port} 'cd ${project.root}; git pull origin master ${tag}'" />
+        <exec logoutput="true" checkreturn="true" command="ssh ${ssh.user}@${ssh.host} -p ${ssh.port} 'cd ${project.root}; sudo git pull origin master ${tag}'" />
     </target>
 
     <target hidden="true" name="composer-install">


### PR DESCRIPTION
This PR

- [x] updates the `git-pull` task to use `sudo` when actually pulling the changes onto the production server

:bulb: Other than that, the deployment script worked for deploying [1.2.1](https://github.com/zendframework/modules.zendframework.com/releases/tag/1.2.1)!