### PR TITLE
Enhancement: Allow to specify tag to deploy

### DIFF
--- a/build.properties.dist
+++ b/build.properties.dist
@@ -3,3 +3,5 @@ ssh.host =
 ssh.port =
 
 project.root =
+
+tag =

--- a/build.xml
+++ b/build.xml
@@ -9,7 +9,7 @@
 
     <target hidden="true" name="git-pull">
         <echo message="Pull changes from origin" />
-        <exec logoutput="true" checkreturn="true" command="ssh ${ssh.user}@${ssh.host} -p ${ssh.port} 'cd ${project.root}; git pull origin master'" />
+        <exec logoutput="true" checkreturn="true" command="ssh ${ssh.user}@${ssh.host} -p ${ssh.port} 'cd ${project.root}; git pull origin master ${tag}'" />
     </target>
 
     <target hidden="true" name="composer-install">


### PR DESCRIPTION
This PR

* [x] allows to specify a tag when deploying

```
$ vendor/bin/phing deploy -Dtag=1.2.1
```