### PR TITLE
Fix: Sort rules in .gitignore alphabetically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 .idea/
 .php_cs.cache
+.vagrant
 build.properties
 clover.xml
-.vagrant
-vendor
 config/development.config.php
+data/logs/*
 puphpet/files/dot/ssh
 !puphpet/files/dot/ssh/insecure_private_key
-data/logs/*
+vendor


### PR DESCRIPTION
This PR

* [x] sorts rules in `.gitignore` alphabetically, both making it more obvious in which way to add new rules, and easier to spot duplicates