### PR TITLE
Fix: GitHub API response for contributors

### DIFF
--- a/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
+++ b/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
@@ -566,17 +566,21 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @link https://developer.github.com/v3/repos/#response-5
+     * @link https://developer.github.com/v3/repos/statistics/#response
      *
      * @return stdClass
      */
     private function contributor()
     {
+        $author = new stdClass();
+
+        $author->login = $this->faker()->unique()->userName;
+        $author->avatar_url = $this->faker()->unique()->url;
+        $author->html_url = $this->faker()->unique()->url;
+
         $contributor = new stdClass();
 
-        $contributor->login = $this->faker()->unique()->userName;
-        $contributor->avatar_url = $this->faker()->unique()->url;
-        $contributor->html_url = $this->faker()->unique()->url;
+        $contributor->author = $author;
 
         return $contributor;
     }

--- a/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
+++ b/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
@@ -517,7 +517,7 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
 
         array_walk($contributors, function ($contributor) use (&$contributorsAsReturned) {
 
-            $expectedContributor = array_pop($contributorsAsReturned);
+            $expected = array_pop($contributorsAsReturned);
 
             $this->assertInternalType('array', $contributor);
             $this->assertArrayHasKey('author', $contributor);
@@ -527,13 +527,13 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
             $this->assertInternalType('array', $author);
 
             $this->assertArrayHasKey('login', $author);
-            $this->assertSame($expectedContributor->author->login, $author['login']);
+            $this->assertSame($expected->author->login, $author['login']);
 
             $this->assertArrayHasKey('avatar_url', $author);
-            $this->assertSame($expectedContributor->author->avatar_url, $author['avatar_url']);
+            $this->assertSame($expected->author->avatar_url, $author['avatar_url']);
 
             $this->assertArrayHasKey('html_url', $author);
-            $this->assertSame($expectedContributor->author->html_url, $author['html_url']);
+            $this->assertSame($expected->author->html_url, $author['html_url']);
         });
     }
 

--- a/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
+++ b/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
@@ -458,9 +458,14 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
 
         array_walk($contributors, function ($contributor) {
             $this->assertInternalType('array', $contributor);
-            $this->assertArrayHasKey('login', $contributor);
-            $this->assertArrayHasKey('avatar_url', $contributor);
-            $this->assertArrayHasKey('html_url', $contributor);
+            $this->assertArrayHasKey('author', $contributor);
+
+            $author = $contributor['author'];
+
+            $this->assertInternalType('array', $author);
+            $this->assertArrayHasKey('login', $author);
+            $this->assertArrayHasKey('avatar_url', $author);
+            $this->assertArrayHasKey('html_url', $author);
         });
     }
 
@@ -515,15 +520,20 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
             $expectedContributor = array_pop($contributorsAsReturned);
 
             $this->assertInternalType('array', $contributor);
+            $this->assertArrayHasKey('author', $contributor);
 
-            $this->assertArrayHasKey('login', $contributor);
-            $this->assertSame($expectedContributor->login, $contributor['login']);
+            $author = $contributor['author'];
 
-            $this->assertArrayHasKey('avatar_url', $contributor);
-            $this->assertSame($expectedContributor->avatar_url, $contributor['avatar_url']);
+            $this->assertInternalType('array', $author);
 
-            $this->assertArrayHasKey('html_url', $contributor);
-            $this->assertSame($expectedContributor->html_url, $contributor['html_url']);
+            $this->assertArrayHasKey('login', $author);
+            $this->assertSame($expectedContributor->author->login, $author['login']);
+
+            $this->assertArrayHasKey('avatar_url', $author);
+            $this->assertSame($expectedContributor->author->avatar_url, $author['avatar_url']);
+
+            $this->assertArrayHasKey('html_url', $author);
+            $this->assertSame($expectedContributor->author->html_url, $author['html_url']);
         });
     }
 


### PR DESCRIPTION
This PR

* [x] fixes the response mimicked in tests related to `Service\RepositoryRetriever::getContributors()` as the GitHub API response has a different format, actually
* [x] fixes the tests making use of that mimicked response

Follows #447.

Sorry, my bad!