### PR TITLE
Fix: Configuration key for GitHub repository

### DIFF
--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -7,10 +7,8 @@ use Psr\Log;
 
 return [
     'github_repository' => [
-        'repository' => [
-            'owner' => 'zendframework',
-            'name'  => 'modules.zendframework.com',
-        ],
+        'owner' => 'zendframework',
+        'name'  => 'modules.zendframework.com',
     ],
     'router' => [
         'routes' => [

--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -6,7 +6,7 @@ use Application\View;
 use Psr\Log;
 
 return [
-    'zf_modules' => [
+    'github_repository' => [
         'repository' => [
             'owner' => 'zendframework',
             'name'  => 'modules.zendframework.com',

--- a/module/Application/config/module.config.php
+++ b/module/Application/config/module.config.php
@@ -6,7 +6,7 @@ use Application\View;
 use Psr\Log;
 
 return [
-    'zf-modules' => [
+    'zf_modules' => [
         'repository' => [
             'owner' => 'zendframework',
             'name'  => 'modules.zendframework.com',

--- a/module/Application/src/Application/Controller/ContributorsControllerFactory.php
+++ b/module/Application/src/Application/Controller/ContributorsControllerFactory.php
@@ -21,7 +21,7 @@ class ContributorsControllerFactory implements FactoryInterface
         /* @var Service\RepositoryRetriever $repositoryRetriever */
         $repositoryRetriever = $serviceManager->get(Service\RepositoryRetriever::class);
 
-        $repositoryData = $serviceManager->get('Config')['zf-modules']['repository'];
+        $repositoryData = $serviceManager->get('Config')['zf_modules']['repository'];
 
         return new ContributorsController(
             $repositoryRetriever,

--- a/module/Application/src/Application/Controller/ContributorsControllerFactory.php
+++ b/module/Application/src/Application/Controller/ContributorsControllerFactory.php
@@ -21,7 +21,7 @@ class ContributorsControllerFactory implements FactoryInterface
         /* @var Service\RepositoryRetriever $repositoryRetriever */
         $repositoryRetriever = $serviceManager->get(Service\RepositoryRetriever::class);
 
-        $repositoryData = $serviceManager->get('Config')['zf_modules']['repository'];
+        $repositoryData = $serviceManager->get('Config')['github_repository']['repository'];
 
         return new ContributorsController(
             $repositoryRetriever,

--- a/module/Application/src/Application/Controller/ContributorsControllerFactory.php
+++ b/module/Application/src/Application/Controller/ContributorsControllerFactory.php
@@ -21,7 +21,7 @@ class ContributorsControllerFactory implements FactoryInterface
         /* @var Service\RepositoryRetriever $repositoryRetriever */
         $repositoryRetriever = $serviceManager->get(Service\RepositoryRetriever::class);
 
-        $repositoryData = $serviceManager->get('Config')['github_repository']['repository'];
+        $repositoryData = $serviceManager->get('Config')['github_repository'];
 
         return new ContributorsController(
             $repositoryRetriever,

--- a/module/Application/src/Application/View/Helper/GitHubRepositoryUrlFactory.php
+++ b/module/Application/src/Application/View/Helper/GitHubRepositoryUrlFactory.php
@@ -18,7 +18,7 @@ class GitHubRepositoryUrlFactory implements FactoryInterface
         /* @var HelperPluginManager $serviceLocator */
         $serviceManager = $serviceLocator->getServiceLocator();
 
-        $config = $serviceManager->get('Config')['zf-modules']['repository'];
+        $config = $serviceManager->get('Config')['zf_modules']['repository'];
 
         return new GitHubRepositoryUrl(
             $config['owner'],

--- a/module/Application/src/Application/View/Helper/GitHubRepositoryUrlFactory.php
+++ b/module/Application/src/Application/View/Helper/GitHubRepositoryUrlFactory.php
@@ -18,7 +18,7 @@ class GitHubRepositoryUrlFactory implements FactoryInterface
         /* @var HelperPluginManager $serviceLocator */
         $serviceManager = $serviceLocator->getServiceLocator();
 
-        $config = $serviceManager->get('Config')['zf_modules']['repository'];
+        $config = $serviceManager->get('Config')['github_repository']['repository'];
 
         return new GitHubRepositoryUrl(
             $config['owner'],

--- a/module/Application/src/Application/View/Helper/GitHubRepositoryUrlFactory.php
+++ b/module/Application/src/Application/View/Helper/GitHubRepositoryUrlFactory.php
@@ -18,7 +18,7 @@ class GitHubRepositoryUrlFactory implements FactoryInterface
         /* @var HelperPluginManager $serviceLocator */
         $serviceManager = $serviceLocator->getServiceLocator();
 
-        $config = $serviceManager->get('Config')['github_repository']['repository'];
+        $config = $serviceManager->get('Config')['github_repository'];
 
         return new GitHubRepositoryUrl(
             $config['owner'],

--- a/module/Application/test/ApplicationTest/Integration/Controller/ContributorsControllerTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Controller/ContributorsControllerTest.php
@@ -26,10 +26,8 @@ class ContributorsControllerTest extends AbstractHttpControllerTestCase
         $config = $this->getApplicationServiceLocator()->get('Config');
 
         $config['github_repository'] = [
-            'repository' => [
-                'owner' => $vendor,
-                'name'  => $name,
-            ],
+            'owner' => $vendor,
+            'name'  => $name,
         ];
 
         $repositoryRetriever = $this->getMockBuilder(Service\RepositoryRetriever::class)

--- a/module/Application/test/ApplicationTest/Integration/Controller/ContributorsControllerTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Controller/ContributorsControllerTest.php
@@ -25,7 +25,7 @@ class ContributorsControllerTest extends AbstractHttpControllerTestCase
 
         $config = $this->getApplicationServiceLocator()->get('Config');
 
-        $config['zf_modules'] = [
+        $config['github_repository'] = [
             'repository' => [
                 'owner' => $vendor,
                 'name'  => $name,

--- a/module/Application/test/ApplicationTest/Integration/Controller/ContributorsControllerTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Controller/ContributorsControllerTest.php
@@ -25,7 +25,7 @@ class ContributorsControllerTest extends AbstractHttpControllerTestCase
 
         $config = $this->getApplicationServiceLocator()->get('Config');
 
-        $config['zf-modules'] = [
+        $config['zf_modules'] = [
             'repository' => [
                 'owner' => $vendor,
                 'name'  => $name,


### PR DESCRIPTION
This PR

* [x] fixes the configuration key to follow the convention to use underscores, see https://github.com/zendframework/modules.zendframework.com/pull/447#discussion_r25640686
* [x] comes up with a (hopefully) less generic configuration key, see https://github.com/zendframework/modules.zendframework.com/pull/447#discussion_r25743523
* [x] flattens the configuration array

Follows #447.