### PR TITLE
Enhancement: Reponsiveness of contributors grid

### DIFF
--- a/module/Application/view/application/contributors/index.phtml
+++ b/module/Application/view/application/contributors/index.phtml
@@ -3,7 +3,7 @@
 <h1>Contributors Hall of Fame</h1>
 
 <div class="row">
-    <div class="col-md-12">
+    <div class="col-lg-12">
         <p>
             We have <strong><?php echo $this->escapeHtml($this->metadata->forks_count); ?> forks</strong>,
             <strong><?php echo $this->escapeHtml($this->metadata->stargazers_count); ?> stargazers</strong>,
@@ -11,14 +11,16 @@
             <strong>awesome contributors</strong> who make this site better.
             <a href="<?php echo $this->escapeHtmlAttr($this->gitHubRepositoryUrl()); ?>" target="_blank">Join us!</a>
         </p>
-        <?php foreach ($this->contributors as $contributor): ?>
-            <?php $url = $contributor['author']['html_url']; ?>
-            <a href="<?php echo $this->escapeHtmlAttr($url); ?>" class="thumbnail col-md-1" target="_blank">
-                <?php $src = $contributor['author']['avatar_url']; ?>
-                <?php $alt = $contributor['author']['login']; ?>
-                <?php $title = sprintf('%s with %d contributions', $alt, $contributor['total']); ?>
-                <img src="<?php echo $this->escapeHtmlAttr($src); ?>" alt="<?php echo $this->escapeHtmlAttr($alt); ?>" title="<?php echo $this->escapeHtmlAttr($title); ?>" width="80px" height="80px">
-            </a>
-        <?php endforeach; ?>
     </div>
+    <?php foreach ($this->contributors as $contributor): ?>
+    <div class="col-lg-1 col-md-2 col-sm-2 col-xs-3">
+        <?php $url = $contributor['author']['html_url']; ?>
+        <a href="<?php echo $this->escapeHtmlAttr($url); ?>" class="thumbnail img-responsive" target="_blank">
+            <?php $src = $contributor['author']['avatar_url']; ?>
+            <?php $alt = $contributor['author']['login']; ?>
+            <?php $title = sprintf('%s with %d contributions', $alt, $contributor['total']); ?>
+            <img src="<?php echo $this->escapeHtmlAttr($src); ?>" alt="<?php echo $this->escapeHtmlAttr($alt); ?>" title="<?php echo $this->escapeHtmlAttr($title); ?>">
+        </a>
+    </div>
+    <?php endforeach; ?>
 </div>


### PR DESCRIPTION
This PR

* [x] improves the responsiveness of the contributors grid

See http://bootply.com/d08bOti6Zs.

## Examples
![screen shot 2015-03-04 at 17 18 17](https://cloud.githubusercontent.com/assets/605483/6487696/fb43e018-c292-11e4-8694-27ccee0e8e70.png)
![screen shot 2015-03-04 at 17 18 53](https://cloud.githubusercontent.com/assets/605483/6487697/fb6af19e-c292-11e4-8136-f4883524e25d.png)
![screen shot 2015-03-04 at 17 19 17](https://cloud.githubusercontent.com/assets/605483/6487699/fb7a5422-c292-11e4-85de-e977229fe1e8.png)
![screen shot 2015-03-04 at 17 19 29](https://cloud.githubusercontent.com/assets/605483/6487698/fb6ff2b6-c292-11e4-8f7d-2a6489d0ae4d.png)
