### PR TITLE
Fix: Single quotes

### DIFF
--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/UserControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/UserControllerTest.php
@@ -27,7 +27,7 @@ class UserControllerTest extends AbstractHttpControllerTestCase
             ->with(
                 $this->equalTo(1),
                 $this->equalTo(10),
-                $this->equalTo("gianarb"),
+                $this->equalTo('gianarb'),
                 $this->equalTo('created_at'),
                 $this->equalTo('DESC')
             )


### PR DESCRIPTION
This PR

* [x] replaces `"` with `'` in one occasion

Follows #444.