### PR TITLE
Fix: Integration test for User controller fails because of lack of mocking

### DIFF
--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/UserControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/UserControllerTest.php
@@ -20,6 +20,8 @@ class UserControllerTest extends AbstractHttpControllerTestCase
 
     public function testUserPageCanBeAccessed()
     {
+        $userName = 'gianarb';
+
         $moduleMapper = $this->getMockBuilder(Mapper\Module::class)->getMock();
 
         $moduleMapper
@@ -28,7 +30,7 @@ class UserControllerTest extends AbstractHttpControllerTestCase
             ->with(
                 $this->equalTo(1),
                 $this->equalTo(10),
-                $this->equalTo('gianarb'),
+                $this->equalTo($userName),
                 $this->equalTo('created_at'),
                 $this->equalTo('DESC')
             )
@@ -50,7 +52,12 @@ class UserControllerTest extends AbstractHttpControllerTestCase
             )
         ;
 
-        $this->dispatch('/user/gianarb');
+        $url = sprintf(
+            '/user/%s',
+            $userName
+        );
+
+        $this->dispatch($url);
 
         $this->assertControllerName(Controller\UserController::class);
         $this->assertActionName('modulesForUser');

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/UserControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/UserControllerTest.php
@@ -35,6 +35,13 @@ class UserControllerTest extends AbstractHttpControllerTestCase
             ->willReturn(new Paginator\Paginator(new Paginator\Adapter\Null()))
         ;
 
+        $moduleMapper
+            ->expects($this->any())
+            ->method('findAll')
+            ->with($this->anything())
+            ->willReturn([])
+        ;
+
         $this->getApplicationServiceLocator()
             ->setAllowOverride(true)
             ->setService(

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/UserControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/UserControllerTest.php
@@ -3,6 +3,7 @@
 namespace ZfModuleTest\Integration\Controller;
 
 use ApplicationTest\Integration\Util\Bootstrap;
+use Zend\Http;
 use Zend\Paginator;
 use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
 use ZfModule\Controller;
@@ -46,5 +47,6 @@ class UserControllerTest extends AbstractHttpControllerTestCase
 
         $this->assertControllerName(Controller\UserController::class);
         $this->assertActionName('modulesForUser');
+        $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
     }
 }


### PR DESCRIPTION
This PR

* [x] adds a failing assertion
* [x] mocks `Mapper\User` to fix the failing test
* [x] introduces a variable to avoid duplication

Follows #444.
Spotted in #462.