### PR TITLE
Fix: Config key should be 'constraints' instead of 'constrains'

### DIFF
--- a/module/ZfModule/config/module.config.php
+++ b/module/ZfModule/config/module.config.php
@@ -54,7 +54,7 @@ return [
                         'type'    => 'Segment',
                         'options' => [
                             'route'      => '/list[/:owner]',
-                            'constrains' => [
+                            'constraints' => [
                                 'owner' => '[a-zA-Z][a-zA-Z0-9_-]*',
                             ],
                             'defaults'   => [


### PR DESCRIPTION
This PR

* [x] adds a failing test
* [x] fixes a config key, which should be `constraints` instead of `constrains`

Related to #462.