### PR TITLE
Fix: organizationAction() should be listAction()

### DIFF
--- a/module/ZfModule/config/module.config.php
+++ b/module/ZfModule/config/module.config.php
@@ -58,7 +58,7 @@ return [
                                 'owner' => '[a-zA-Z][a-zA-Z0-9_-]*',
                             ],
                             'defaults'   => [
-                                'action' => 'organization',
+                                'action' => 'list',
                             ],
                         ],
                     ],

--- a/module/ZfModule/src/ZfModule/Controller/ModuleController.php
+++ b/module/ZfModule/src/ZfModule/Controller/ModuleController.php
@@ -98,7 +98,7 @@ class ModuleController extends AbstractActionController
         return $viewModel;
     }
 
-    public function organizationAction()
+    public function listAction()
     {
         if (!$this->zfcUserAuthentication()->hasIdentity()) {
             return $this->redirect()->toRoute('zfcuser/login');

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/ModuleControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/ModuleControllerTest.php
@@ -168,7 +168,7 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
         $this->assertSame($unregisteredModule, $viewVariable[0]);
     }
 
-    public function testOrganizationActionRedirectsIfNotAuthenticated()
+    public function testListActionRedirectsIfNotAuthenticated()
     {
         $this->notAuthenticated();
 
@@ -182,13 +182,13 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
         $this->dispatch($url);
 
         $this->assertControllerName(Controller\ModuleController::class);
-        $this->assertActionName('organization');
+        $this->assertActionName('list');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_302);
 
         $this->assertRedirectTo('/user/login');
     }
 
-    public function testOrganizationActionFetches100MostRecentlyUpdatedRepositoriesWhenNoOwnerIsSpecified()
+    public function testListActionFetches100MostRecentlyUpdatedRepositoriesWhenNoOwnerIsSpecified()
     {
         $this->authenticatedAs(new User());
 
@@ -224,15 +224,15 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
         $this->dispatch('/module/list');
 
         $this->assertControllerName(Controller\ModuleController::class);
-        $this->assertActionName('organization');
+        $this->assertActionName('list');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
     }
 
     /**
      * @dataProvider providerInvalidVendor
-     * @param $vendor
+     * @param string $vendor
      */
-    public function testOrganizationActionDoesNotMatchOnInvalidVendor($vendor)
+    public function testListActionDoesNotMatchOnInvalidVendor($vendor)
     {
         $this->authenticatedAs(new User());
 
@@ -289,7 +289,7 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
         ];
     }
 
-    public function testOrganizationActionFetches100MostRecentlyUpdatedRepositoriesWithOwnerSpecified()
+    public function testListActionFetches100MostRecentlyUpdatedRepositoriesWithOwnerSpecified()
     {
         $this->authenticatedAs(new User());
 
@@ -332,11 +332,11 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
         $this->dispatch($url);
 
         $this->assertControllerName(Controller\ModuleController::class);
-        $this->assertActionName('organization');
+        $this->assertActionName('list');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
     }
 
-    public function testOrganizationActionRendersUnregisteredModulesOnly()
+    public function testListActionRendersUnregisteredModulesOnly()
     {
         $this->authenticatedAs(new User());
 
@@ -411,7 +411,7 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
         $this->dispatch($url);
 
         $this->assertControllerName(Controller\ModuleController::class);
-        $this->assertActionName('organization');
+        $this->assertActionName('list');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
 
         /* @var Mvc\Application $application */


### PR DESCRIPTION
This PR

* [x] renames `Controller\IndexController::organizationAction()` to `listAction()` because that's what is in the route name, and also, what the action does, that is, list modules

:bulb: Controller should probably be named differently as well, e.g., `ModuleController`