### PR TITLE
Fix: Factory creates a UserController, not an IndexController

### DIFF
--- a/module/ZfModule/src/ZfModule/Controller/UserControllerFactory.php
+++ b/module/ZfModule/src/ZfModule/Controller/UserControllerFactory.php
@@ -12,7 +12,7 @@ class UserControllerFactory implements FactoryInterface
 {
     /**
      * @param ServiceLocatorInterface $controllerManager
-     * @return IndexController
+     * @return UserController
      */
     public function createService(ServiceLocatorInterface $controllerManager)
     {


### PR DESCRIPTION
This PR

* [x] fixes the annotation of `Controller\UserControllerFactory::createService()` as it returns a `UserController`, not an `IndexController`

:bulb: Yes, I stumbled upon this when renaming `Controller\IndexController` to `Controller\ModuleController`.

Related to #468.