### PR TITLE
Fix: Do not json_decode API response to associative array

### DIFF
--- a/module/Application/src/Application/Service/RepositoryRetriever.php
+++ b/module/Application/src/Application/Service/RepositoryRetriever.php
@@ -64,7 +64,7 @@ class RepositoryRetriever
     {
         try {
             $contributors = $this->githubClient->api('repos')->contributors($owner, $repo);
-            $data = json_decode($contributors, true);
+            $data = json_decode($contributors);
 
             return array_reverse($data);
         } catch (RuntimeException $e) {

--- a/module/Application/test/ApplicationTest/Integration/Controller/ContributorsControllerTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Controller/ContributorsControllerTest.php
@@ -6,12 +6,15 @@ use Application\Controller;
 use Application\Entity;
 use Application\Service;
 use ApplicationTest\Integration\Util\Bootstrap;
+use ApplicationTest\Util\FakerTrait;
 use stdClass;
 use Zend\Http;
 use Zend\Test\PHPUnit\Controller\AbstractHttpControllerTestCase;
 
 class ContributorsControllerTest extends AbstractHttpControllerTestCase
 {
+    use FakerTrait;
+
     protected function setUp()
     {
         parent::setUp();
@@ -46,6 +49,8 @@ class ContributorsControllerTest extends AbstractHttpControllerTestCase
             ->getMock()
         ;
 
+        $contributors = $this->contributors(5);
+
         $repositoryRetriever
             ->expects($this->once())
             ->method('getContributors')
@@ -53,7 +58,7 @@ class ContributorsControllerTest extends AbstractHttpControllerTestCase
                 $this->equalTo($vendor),
                 $this->equalTo($name)
             )
-            ->willReturn([])
+            ->willReturn($contributors)
         ;
 
         $metaData = new stdClass();
@@ -88,5 +93,35 @@ class ContributorsControllerTest extends AbstractHttpControllerTestCase
         $this->assertControllerName(Controller\ContributorsController::class);
         $this->assertActionName('index');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
+    }
+
+    /**
+     * @return array
+     */
+    private function contributor()
+    {
+        return [
+            'author' => [
+                'login' => $this->faker()->unique()->userName,
+                'avatar_url' => $this->faker()->unique()->url,
+                'html_url' => $this->faker()->unique()->url,
+            ],
+            'total' => $this->faker()->randomNumber(),
+        ];
+    }
+
+    /**
+     * @param int $count
+     * @return stdClass[]
+     */
+    private function contributors($count)
+    {
+        $contributors = [];
+
+        for ($i = 0; $i < $count; $i++) {
+            array_push($contributors, $this->contributor());
+        }
+
+        return $contributors;
     }
 }

--- a/module/Application/test/ApplicationTest/Integration/Controller/ContributorsControllerTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Controller/ContributorsControllerTest.php
@@ -96,18 +96,24 @@ class ContributorsControllerTest extends AbstractHttpControllerTestCase
     }
 
     /**
-     * @return array
+     * @link https://developer.github.com/v3/repos/statistics/#response
+     *
+     * @return stdClass
      */
     private function contributor()
     {
-        return [
-            'author' => [
-                'login' => $this->faker()->unique()->userName,
-                'avatar_url' => $this->faker()->unique()->url,
-                'html_url' => $this->faker()->unique()->url,
-            ],
-            'total' => $this->faker()->randomNumber(),
-        ];
+        $author = new stdClass();
+
+        $author->login = $this->faker()->unique()->userName;
+        $author->avatar_url = $this->faker()->unique()->url;
+        $author->html_url = $this->faker()->unique()->url;
+
+        $contributor = new stdClass();
+
+        $contributor->author = $author;
+        $contributor->total = $this->faker()->randomNumber();
+
+        return $contributor;
     }
 
     /**

--- a/module/Application/test/ApplicationTest/Integration/Controller/ContributorsControllerTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Controller/ContributorsControllerTest.php
@@ -102,16 +102,15 @@ class ContributorsControllerTest extends AbstractHttpControllerTestCase
      */
     private function contributor()
     {
-        $author = new stdClass();
-
-        $author->login = $this->faker()->unique()->userName;
-        $author->avatar_url = $this->faker()->unique()->url;
-        $author->html_url = $this->faker()->unique()->url;
-
         $contributor = new stdClass();
 
-        $contributor->author = $author;
         $contributor->total = $this->faker()->randomNumber();
+
+        $contributor->author = new stdClass();
+
+        $contributor->author->login = $this->faker()->unique()->userName;
+        $contributor->author->avatar_url = $this->faker()->unique()->url;
+        $contributor->author->html_url = $this->faker()->unique()->url;
 
         return $contributor;
     }

--- a/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
+++ b/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
@@ -363,6 +363,8 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
 
         array_walk($contributors, function ($contributor) {
             $this->assertInternalType('array', $contributor);
+
+            $this->assertArrayHasKey('total', $contributor);
             $this->assertArrayHasKey('author', $contributor);
 
             $author = $contributor['author'];
@@ -425,6 +427,10 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
             $expected = array_pop($contributorsAsReturned);
 
             $this->assertInternalType('array', $contributor);
+
+            $this->assertArrayHasKey('total', $contributor);
+            $this->assertSame($expected->total, $contributor['total']);
+
             $this->assertArrayHasKey('author', $contributor);
 
             $author = $contributor['author'];
@@ -496,6 +502,7 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
         $contributor = new stdClass();
 
         $contributor->author = $author;
+        $contributor->total = $this->faker()->randomNumber();
 
         return $contributor;
     }

--- a/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
+++ b/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
@@ -365,14 +365,13 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
             $this->assertInstanceOf(stdClass::class, $contributor);
 
             $this->assertObjectHasAttribute('total', $contributor);
+
             $this->assertObjectHasAttribute('author', $contributor);
+            $this->assertInstanceOf(stdClass::class, $contributor->author);
 
-            $author = $contributor->author;
-
-            $this->assertInstanceOf(stdClass::class, $author);
-            $this->assertObjectHasAttribute('login', $author);
-            $this->assertObjectHasAttribute('avatar_url', $author);
-            $this->assertObjectHasAttribute('html_url', $author);
+            $this->assertObjectHasAttribute('login', $contributor->author);
+            $this->assertObjectHasAttribute('avatar_url', $contributor->author);
+            $this->assertObjectHasAttribute('html_url', $contributor->author);
         });
     }
 
@@ -432,19 +431,16 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
             $this->assertSame($expected->total, $contributor->total);
 
             $this->assertObjectHasAttribute('author', $contributor);
+            $this->assertInstanceOf(stdClass::class, $contributor->author);
 
-            $author = $contributor->author;
+            $this->assertObjectHasAttribute('login', $contributor->author);
+            $this->assertSame($expected->author->login, $contributor->author->login);
 
-            $this->assertInstanceOf(stdClass::class, $author);
+            $this->assertObjectHasAttribute('avatar_url', $contributor->author);
+            $this->assertSame($expected->author->avatar_url, $contributor->author->avatar_url);
 
-            $this->assertObjectHasAttribute('login', $author);
-            $this->assertSame($expected->author->login, $author->login);
-
-            $this->assertObjectHasAttribute('avatar_url', $author);
-            $this->assertSame($expected->author->avatar_url, $author->avatar_url);
-
-            $this->assertObjectHasAttribute('html_url', $author);
-            $this->assertSame($expected->author->html_url, $author->html_url);
+            $this->assertObjectHasAttribute('html_url', $contributor->author);
+            $this->assertSame($expected->author->html_url, $contributor->author->html_url);
         });
     }
 
@@ -493,16 +489,15 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
      */
     private function contributor()
     {
-        $author = new stdClass();
-
-        $author->login = $this->faker()->unique()->userName;
-        $author->avatar_url = $this->faker()->unique()->url;
-        $author->html_url = $this->faker()->unique()->url;
-
         $contributor = new stdClass();
 
-        $contributor->author = $author;
         $contributor->total = $this->faker()->randomNumber();
+
+        $contributor->author = new stdClass();
+
+        $contributor->author->login = $this->faker()->unique()->userName;
+        $contributor->author->avatar_url = $this->faker()->unique()->url;
+        $contributor->author->html_url = $this->faker()->unique()->url;
 
         return $contributor;
     }

--- a/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
+++ b/module/Application/test/ApplicationTest/Service/RepositoryRetrieverTest.php
@@ -362,17 +362,17 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
         $this->assertInternalType('array', $contributors);
 
         array_walk($contributors, function ($contributor) {
-            $this->assertInternalType('array', $contributor);
+            $this->assertInstanceOf(stdClass::class, $contributor);
 
-            $this->assertArrayHasKey('total', $contributor);
-            $this->assertArrayHasKey('author', $contributor);
+            $this->assertObjectHasAttribute('total', $contributor);
+            $this->assertObjectHasAttribute('author', $contributor);
 
-            $author = $contributor['author'];
+            $author = $contributor->author;
 
-            $this->assertInternalType('array', $author);
-            $this->assertArrayHasKey('login', $author);
-            $this->assertArrayHasKey('avatar_url', $author);
-            $this->assertArrayHasKey('html_url', $author);
+            $this->assertInstanceOf(stdClass::class, $author);
+            $this->assertObjectHasAttribute('login', $author);
+            $this->assertObjectHasAttribute('avatar_url', $author);
+            $this->assertObjectHasAttribute('html_url', $author);
         });
     }
 
@@ -426,25 +426,25 @@ class RepositoryRetrieverTest extends PHPUnit_Framework_TestCase
 
             $expected = array_pop($contributorsAsReturned);
 
-            $this->assertInternalType('array', $contributor);
+            $this->assertInstanceOf(stdClass::class, $contributor);
 
-            $this->assertArrayHasKey('total', $contributor);
-            $this->assertSame($expected->total, $contributor['total']);
+            $this->assertObjectHasAttribute('total', $contributor);
+            $this->assertSame($expected->total, $contributor->total);
 
-            $this->assertArrayHasKey('author', $contributor);
+            $this->assertObjectHasAttribute('author', $contributor);
 
-            $author = $contributor['author'];
+            $author = $contributor->author;
 
-            $this->assertInternalType('array', $author);
+            $this->assertInstanceOf(stdClass::class, $author);
 
-            $this->assertArrayHasKey('login', $author);
-            $this->assertSame($expected->author->login, $author['login']);
+            $this->assertObjectHasAttribute('login', $author);
+            $this->assertSame($expected->author->login, $author->login);
 
-            $this->assertArrayHasKey('avatar_url', $author);
-            $this->assertSame($expected->author->avatar_url, $author['avatar_url']);
+            $this->assertObjectHasAttribute('avatar_url', $author);
+            $this->assertSame($expected->author->avatar_url, $author->avatar_url);
 
-            $this->assertArrayHasKey('html_url', $author);
-            $this->assertSame($expected->author->html_url, $author['html_url']);
+            $this->assertObjectHasAttribute('html_url', $author);
+            $this->assertSame($expected->author->html_url, $author->html_url);
         });
     }
 

--- a/module/Application/view/application/contributors/index.phtml
+++ b/module/Application/view/application/contributors/index.phtml
@@ -14,11 +14,11 @@
     </div>
     <?php foreach ($this->contributors as $contributor): ?>
     <div class="col-lg-1 col-md-2 col-sm-2 col-xs-3">
-        <?php $url = $contributor['author']['html_url']; ?>
+        <?php $url = $contributor->author->html_url; ?>
         <a href="<?php echo $this->escapeHtmlAttr($url); ?>" class="thumbnail img-responsive" target="_blank">
-            <?php $src = $contributor['author']['avatar_url']; ?>
-            <?php $alt = $contributor['author']['login']; ?>
-            <?php $title = sprintf('%s with %d contributions', $alt, $contributor['total']); ?>
+            <?php $src = $contributor->author->avatar_url; ?>
+            <?php $alt = $contributor->author->login; ?>
+            <?php $title = sprintf('%s with %d contributions', $alt, $contributor->total); ?>
             <img src="<?php echo $this->escapeHtmlAttr($src); ?>" alt="<?php echo $this->escapeHtmlAttr($alt); ?>" title="<?php echo $this->escapeHtmlAttr($title); ?>">
         </a>
     </div>


### PR DESCRIPTION
This PR

* [x] updates an integration test for the `ContributorsController::contributorsAction()` by actually providing the view with some contributor data
* [x] updates the tests expectations (and a view template relying on these expectations as well) for `RepositoryRetriever::getContributors()` to `json_decode` to objects
* [x] fixes the failing tests by actually `json_decode`ing to objects

See https://github.com/zendframework/modules.zendframework.com/pull/447#discussion_r25690636.