### PR TITLE
Enhancement: added hhvm as allow failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ php:
   - 5.6
   - hhvm
 
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: hhvm
+
 cache:
   directories:
     - $HOME/.composer/cache


### PR DESCRIPTION
as the page runs not on ``hhvm`` it should be marked as ``allow_failures``. 

this would also be required as of pr #421 and the ``hhvm`` exception bug in phpunit - as an fix is not landed in phpunit yet.

PHPUnit Bug: https://github.com/sebastianbergmann/phpunit-mock-objects/issues/207