### PR TITLE
Fix: Do not collect code coverage . . . for now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 .php_cs.cache
 .vagrant
 build.properties
-clover.xml
 config/development.config.php
 data/logs/*
 puphpet/files/dot/ssh

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,7 +23,4 @@
             <directory suffix=".php">./module/ZfModule/src</directory>
         </whitelist>
     </filter>
-    <logging>
-        <log type="coverage-clover" target="./clover.xml" />
-    </logging>
 </phpunit>


### PR DESCRIPTION
This PR

* [x] removes configuration which results in code coverage being collected when running tests

:bulb: We're not using the code coverage data generated on Travis *yet*, so it's a waste of resources (and time). Removing the configuration significantly speeds up the tests, and if one is interested in code coverage, you can still specify a command line option or run the tests from within your favourite IDE™.

#### Before

![screen shot 2015-03-06 at 14 31 32](https://cloud.githubusercontent.com/assets/605483/6526047/8ff380a8-c40d-11e4-847f-f7d64345d72c.png)

#### After

![screen shot 2015-03-06 at 14 31 45](https://cloud.githubusercontent.com/assets/605483/6526049/95f3a208-c40d-11e4-9c89-4cfbc50b734b.png)
