### PR TITLE
Fix: Assert route names

### DIFF
--- a/module/Application/test/ApplicationTest/Integration/Controller/ContributorsControllerTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Controller/ContributorsControllerTest.php
@@ -85,6 +85,8 @@ class ContributorsControllerTest extends AbstractHttpControllerTestCase
 
         $this->dispatch('/contributors');
 
+        $this->assertMatchedRouteName('contributors');
+
         $this->assertControllerName(Controller\ContributorsController::class);
         $this->assertActionName('index');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);

--- a/module/Application/test/ApplicationTest/Integration/Controller/IndexControllerTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Controller/IndexControllerTest.php
@@ -69,6 +69,8 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
 
         $this->dispatch('/');
 
+        $this->assertMatchedRouteName('home');
+
         $this->assertControllerName(Controller\IndexController::class);
         $this->assertActionName('index');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
@@ -100,6 +102,8 @@ class IndexControllerTest extends AbstractHttpControllerTestCase
         ;
 
         $this->dispatch('/feed');
+
+        $this->assertMatchedRouteName('feed');
 
         $this->assertControllerName(Controller\IndexController::class);
         $this->assertActionName('feed');

--- a/module/Application/test/ApplicationTest/Integration/Controller/SearchControllerTest.php
+++ b/module/Application/test/ApplicationTest/Integration/Controller/SearchControllerTest.php
@@ -38,6 +38,8 @@ class SearchControllerTest extends AbstractHttpControllerTestCase
 
         $this->dispatch('/live-search');
 
+        $this->assertMatchedRouteName('live-search');
+
         $this->assertControllerName(Controller\SearchController::class);
         $this->assertActionName('index');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);

--- a/module/User/test/UserTest/Integration/Controller/UserControllerTest.php
+++ b/module/User/test/UserTest/Integration/Controller/UserControllerTest.php
@@ -32,6 +32,8 @@ class UserControllerTest extends AbstractHttpControllerTestCase
 
         $this->dispatch('/user');
 
+        $this->assertMatchedRouteName('scn-social-auth-user');
+
         $this->assertControllerName('zfcuser');
         $this->assertActionName('index');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_302);
@@ -102,6 +104,8 @@ class UserControllerTest extends AbstractHttpControllerTestCase
         $this->authenticatedAs(new User());
 
         $this->dispatch('/user');
+
+        $this->assertMatchedRouteName('scn-social-auth-user');
 
         $this->assertControllerName('zfcuser');
         $this->assertActionName('index');

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/ModuleControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/ModuleControllerTest.php
@@ -39,6 +39,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
 
         $this->dispatch('/module');
 
+        $this->assertMatchedRouteName('zf-module');
+
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('index');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_302);
@@ -78,6 +80,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
         ;
 
         $this->dispatch('/module');
+
+        $this->assertMatchedRouteName('zf-module');
 
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('index');
@@ -151,6 +155,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
 
         $this->dispatch('/module');
 
+        $this->assertMatchedRouteName('zf-module');
+
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('index');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
@@ -180,6 +186,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
         );
 
         $this->dispatch($url);
+
+        $this->assertMatchedRouteName('zf-module/list');
 
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('list');
@@ -222,6 +230,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
         ;
 
         $this->dispatch('/module/list');
+
+        $this->assertMatchedRouteName('zf-module/list');
 
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('list');
@@ -331,6 +341,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
 
         $this->dispatch($url);
 
+        $this->assertMatchedRouteName('zf-module/list');
+
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('list');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
@@ -410,11 +422,12 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
 
         $this->dispatch($url);
 
+        $this->assertMatchedRouteName('zf-module/list');
+
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('list');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);
 
-        /* @var Mvc\Application $application */
         $viewModel = $this->getApplication()->getMvcEvent()->getViewModel();
 
         $this->assertTrue($viewModel->terminate());
@@ -432,6 +445,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
         $this->notAuthenticated();
 
         $this->dispatch('/module/add');
+
+        $this->assertMatchedRouteName('zf-module/add');
 
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('add');
@@ -453,6 +468,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
             '/module/add',
             $method
         );
+
+        $this->assertMatchedRouteName('zf-module/add');
 
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('add');
@@ -525,6 +542,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
             ]
         );
 
+        $this->assertMatchedRouteName('zf-module/add');
+
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('add');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_500);
@@ -585,6 +604,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
                 'owner' => $vendor,
             ]
         );
+
+        $this->assertMatchedRouteName('zf-module/add');
 
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('add');
@@ -675,6 +696,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
             ]
         );
 
+        $this->assertMatchedRouteName('zf-module/add');
+
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('add');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_500);
@@ -759,6 +782,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
             ]
         );
 
+        $this->assertMatchedRouteName('zf-module/add');
+
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('add');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_302);
@@ -771,6 +796,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
         $this->notAuthenticated();
 
         $this->dispatch('/module/remove');
+
+        $this->assertMatchedRouteName('zf-module/remove');
 
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('remove');
@@ -792,6 +819,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
             '/module/remove',
             $method
         );
+
+        $this->assertMatchedRouteName('zf-module/remove');
 
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('remove');
@@ -845,6 +874,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
                 'owner' => $vendor,
             ]
         );
+
+        $this->assertMatchedRouteName('zf-module/remove');
 
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('remove');
@@ -906,6 +937,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
                 'owner' => $vendor,
             ]
         );
+
+        $this->assertMatchedRouteName('zf-module/remove');
 
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('remove');
@@ -981,6 +1014,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
                 'owner' => $vendor,
             ]
         );
+
+        $this->assertMatchedRouteName('zf-module/remove');
 
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('remove');
@@ -1067,6 +1102,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
             ]
         );
 
+        $this->assertMatchedRouteName('zf-module/remove');
+
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('remove');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_302);
@@ -1106,6 +1143,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
         );
 
         $this->dispatch($url);
+
+        $this->assertMatchedRouteName('view-module');
 
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('not-found');
@@ -1164,6 +1203,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
 
         $this->dispatch($url);
 
+        $this->assertMatchedRouteName('view-module');
+
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('not-found');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_404);
@@ -1220,6 +1261,8 @@ class ModuleControllerTest extends AbstractHttpControllerTestCase
         );
 
         $this->dispatch($url);
+
+        $this->assertMatchedRouteName('view-module');
 
         $this->assertControllerName(Controller\ModuleController::class);
         $this->assertActionName('view');

--- a/module/ZfModule/test/ZfModuleTest/Integration/Controller/UserControllerTest.php
+++ b/module/ZfModule/test/ZfModuleTest/Integration/Controller/UserControllerTest.php
@@ -59,6 +59,8 @@ class UserControllerTest extends AbstractHttpControllerTestCase
 
         $this->dispatch($url);
 
+        $this->assertMatchedRouteName('modules-for-user');
+
         $this->assertControllerName(Controller\UserController::class);
         $this->assertActionName('modulesForUser');
         $this->assertResponseStatusCode(Http\Response::STATUS_CODE_200);


### PR DESCRIPTION
This PR

* [x] asserts the matched route names in all integration tests to prevent regressions

Related to #462.