### PR TITLE
Removed Twitter box

### DIFF
--- a/module/Application/view/application/index/index.phtml
+++ b/module/Application/view/application/index/index.phtml
@@ -55,15 +55,6 @@
                 </div>
             </div>
         </div>
-        <div class="block">
-            <h4><strong>Twitter</strong></h4>
-            <hr>
-            <div class="row">
-                <div class="col-md-12">
-                    <?php echo $this->twitterWidget(); ?>
-                </div>
-            </div>
-        </div>
         <?php echo $this->newUsers(); ?>
     </div>
 </div>


### PR DESCRIPTION
I don't think the Twitter box is appropriate - we are still piggy backing on Zend's branding, without checking that Zend (or possibly the CR team) are OK with it. I also think that the Twitter account is currently giving no value as nobody is really tweeting with it, and it's in control of one person (which is very dangerous). I'm happy to re-instate this in the future if we get sign off from Zend.