### PR TITLE
Enhancement: Add Scrutinizer badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ZF2 Modules Site [![Build Status](https://travis-ci.org/zendframework/modules.zendframework.com.svg?branch=master)](https://travis-ci.org/zendframework/modules.zendframework.com) [![Dependency Status](https://www.versioneye.com/user/projects/54885d5a746eb514b0000279/badge.svg?style=flat)](https://www.versioneye.com/user/projects/54885d5a746eb514b0000279)
+# ZF2 Modules Site [![Build Status](https://travis-ci.org/zendframework/modules.zendframework.com.svg?branch=master)](https://travis-ci.org/zendframework/modules.zendframework.com) [![Dependency Status](https://www.versioneye.com/user/projects/54885d5a746eb514b0000279/badge.svg?style=flat)](https://www.versioneye.com/user/projects/54885d5a746eb514b0000279) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/badges/quality-score.png?b=develop)](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/?branch=develop) [![Build Status](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/badges/build.png?b=develop)](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/build-status/develop)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# ZF2 Modules Site [![Build Status](https://travis-ci.org/zendframework/modules.zendframework.com.svg?branch=master)](https://travis-ci.org/zendframework/modules.zendframework.com) [![Dependency Status](https://www.versioneye.com/user/projects/54885d5a746eb514b0000279/badge.svg?style=flat)](https://www.versioneye.com/user/projects/54885d5a746eb514b0000279) [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/badges/quality-score.png?b=develop)](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/?branch=develop) [![Build Status](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/badges/build.png?b=develop)](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/build-status/develop)
+# ZF2 Modules Site 
+
+[![Build Status](https://travis-ci.org/zendframework/modules.zendframework.com.svg?branch=master)](https://travis-ci.org/zendframework/modules.zendframework.com) 
+[![Dependency Status](https://www.versioneye.com/user/projects/54885d5a746eb514b0000279/badge.svg?style=flat)](https://www.versioneye.com/user/projects/54885d5a746eb514b0000279) 
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/badges/quality-score.png?b=develop)](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/?branch=develop) 
+[![Build Status](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/badges/build.png?b=develop)](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/build-status/develop)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![Build Status](https://travis-ci.org/zendframework/modules.zendframework.com.svg?branch=master)](https://travis-ci.org/zendframework/modules.zendframework.com) 
 [![Dependency Status](https://www.versioneye.com/user/projects/54885d5a746eb514b0000279/badge.svg?style=flat)](https://www.versioneye.com/user/projects/54885d5a746eb514b0000279) 
-[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/badges/quality-score.png?b=develop)](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/?branch=develop) 
-[![Build Status](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/badges/build.png?b=develop)](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/build-status/develop)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/?branch=master)
+[![Build Status](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/badges/build.png?b=master)](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/build-status/master)
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # ZF2 Modules Site 
 
 [![Build Status](https://travis-ci.org/zendframework/modules.zendframework.com.svg?branch=master)](https://travis-ci.org/zendframework/modules.zendframework.com) 
-[![Dependency Status](https://www.versioneye.com/user/projects/54885d5a746eb514b0000279/badge.svg?style=flat)](https://www.versioneye.com/user/projects/54885d5a746eb514b0000279) 
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/?branch=master)
 [![Build Status](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/badges/build.png?b=master)](https://scrutinizer-ci.com/g/zendframework/modules.zendframework.com/build-status/master)
+[![Dependency Status](https://www.versioneye.com/user/projects/54885d5a746eb514b0000279/badge.svg?style=flat)](https://www.versioneye.com/user/projects/54885d5a746eb514b0000279) 
 
 ## Introduction
 


### PR DESCRIPTION
This PR

* [x] cherry-picks 1f14a2f15f302d4e304b8fe27fb8ecdd6a1ef686
* [x] wraps the badges
* [x] references the `master` branch

Related to #491.

:information_desk_person: It seems that we already have Scrutinizer up and running, why not show the badges already?

### Before

![screen shot 2015-09-19 at 13 01 47](https://cloud.githubusercontent.com/assets/605483/9975924/c24cee34-5ece-11e5-8ed1-d5e94ba1b453.png)

### After

![screen shot 2015-09-19 at 13 02 36](https://cloud.githubusercontent.com/assets/605483/9975925/c7114dc0-5ece-11e5-9f49-67705faa3ea7.png)
