### PR TITLE
Enhancement: Add Makefile with cs and test targets

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,10 +16,10 @@ locally rather than keeping Travis busy doing it. There's not much more pleasing
 
 This projects follows the [PSR-2 Coding Style Guide](http://www.php-fig.org/psr/psr-2/). Be sure to read it!
 
-Before opening a pull request or pushing more commits, you should run coding style checks locally:
- 
+Before opening a pull request or pushing more commits, fix coding style issues locally:
+
 ```
-$ ./vendor/bin/php-cs-fixer fix --config-file=./.php_cs --dry-run --diff -v
+$ make cs
 ```
 
 
@@ -30,7 +30,7 @@ We do have a - somewhat - limited test suite, but are hoping for more.
 Please run the tests locally to see if they pass:
 
 ```
-$ ./vendor/bin/phpunit --configuration phpunit.xml
+$ make test
 ```
 
 ## Contributors

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: composer cs
+
+composer:
+	composer validate
+	composer install --prefer-dist
+
+cs: composer
+	vendor/bin/php-cs-fixer fix --config-file=.php_cs --diff --verbose

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,11 @@ composer:
 
 cs: composer
 	vendor/bin/php-cs-fixer fix --config-file=.php_cs --diff --verbose
+
+test: composer
+	cp config/autoload/travis.php.local.dist config/autoload/travis.local.php
+	mysql -uroot -e 'DROP DATABASE IF EXISTS modules_test;'
+	mysql -uroot -e 'CREATE DATABASE modules_test;'
+	mysql -uroot modules_test < data/sql/0.sql
+	vendor/bin/phpunit --configuration phpunit.xml
+	rm config/autoload/travis.local.php


### PR DESCRIPTION
:exclamation: Blocked by #499.

This PR

* [x] adds a `Makefile` with a `cs` target
* [x] adds a `test` target
* [x] updates `CONTRIBUTING.md`

:information_desk_person: Now it's easier than ever to fix coding style issues or run the tests, just run

```
$ make cs
```

or 

```
$ make test
```