### PR TITLE
Enhancement/Removed hhvm runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ sudo: false
 
 php:
   - 5.6
-  - hhvm
+  - 7
 
 matrix:
   fast_finish: true
   allow_failures:
-    - php: hhvm
+    - php: 7
 
 cache:
   directories:


### PR DESCRIPTION
I think we all agree that the Travis HHVM runs don't accomplish anything and only use resources that we really don't need. 

This PR

- [x] removes Travis HHVM runs
- [x] adds PHP7 Travis runs